### PR TITLE
Add HTTP proxy vars to environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for HTTP proxy configurations ([#5])
+
 ### Changed
 
 - Open source component ([#1])
@@ -14,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#1]: https://github.com/projectsyn/component-cert-manager/pull/1
 [#2]: https://github.com/projectsyn/component-cert-manager/pull/2
+[#5]: https://github.com/projectsyn/component-cert-manager/pull/5

--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -20,6 +20,10 @@ parameters:
           global:
             leaderElection:
               namespace: ${cert_manager:namespace}
+          extraEnv:
+            - HTTP_PROXY: ${cert_manager.http_proxy}
+            - HTTS_PROXY: ${cert_manager.https_proxy}
+            - NO_PROXY: ${cert_manager.no_proxy}
           installCRDs: true
           prometheus:
             servicemonitor:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,3 +4,6 @@ parameters:
     dns01-recursive-nameservers: "1.1.1.1:53"
     charts:
       cert-manager: v0.15.1
+    http_proxy: ""
+    https_proxy: ""
+    no_proxy: ""

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,3 +1,5 @@
 = cert-manager: A Commodore component to manage cert-manager
 
 {doctitle} is a Commodore component for Managing cert-manager.
+
+See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -24,7 +24,8 @@ The version of the Helm chart to use.
 type:: string
 default:: `1.1.1.1:53`
 
-tbd
+Recursive nameservers to use for validating DNS01 challenges.
+See the https://cert-manager.io/docs/configuration/acme/dns01/#setting-nameservers-for-dns01-self-check[cert-manager documentation] for more details.
 
 == `http_proxy`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,7 +16,7 @@ The namespace in which to install cert-manager.
 type:: string
 default:: `v0.15.1`
 
-The version of the chart to use.
+The version of the Helm chart to use.
 
 == `dns01-recursive-nameservers`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -32,7 +32,7 @@ tbd
 type:: string
 default:: ``
 
-HTTP_PROXY configuration that cert-manager should use.
+The value of `http_proxy` is passed to cert-manager in environment variable `HTTP_PROXY`.
 
 
 == `https_proxy`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -1,0 +1,52 @@
+= Parameters
+
+The parent key for all of the following parameters is `cert_manager`.
+
+== `namespace`
+
+[horizontal]
+type:: string
+default:: `syn-cert-manager`
+
+The namespace in which to install cert-manager.
+
+== `charts:cert-manager`
+
+[horizontal]
+type:: string
+default:: `v0.15.1`
+
+The version of the chart to use.
+
+== `dns01-recursive-nameservers`
+
+[horizontal]
+type:: string
+default:: `1.1.1.1:53`
+
+tbd
+
+== `http_proxy`
+
+[horizontal]
+type:: string
+default:: ``
+
+HTTP_PROXY configuration that cert-manager should use.
+
+
+== `https_proxy`
+
+[horizontal]
+type:: string
+default:: ``
+
+HTTPS_PROXY configuration that cert-manager should use.
+
+== `no_proxy`
+
+[horizontal]
+type:: string
+default:: ``
+
+NO_PROXY configuration that cert-manager should use.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -41,7 +41,7 @@ The value of `http_proxy` is passed to cert-manager in environment variable `HTT
 type:: string
 default:: ``
 
-HTTPS_PROXY configuration that cert-manager should use.
+The value of `https_proxy` is passed to cert-manager in environment variable `HTTPS_PROXY`.
 
 == `no_proxy`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -50,4 +50,4 @@ The value of `https_proxy` is passed to cert-manager in environment variable `HT
 type:: string
 default:: ``
 
-NO_PROXY configuration that cert-manager should use.
+The value of `no_proxy` is passed to cert-manager in environment variable `NO_PROXY`.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,1 +1,2 @@
 * xref:index.adoc[Home]
+* xref:references/parameters.adoc[Parameters]


### PR DESCRIPTION
Uses the `extraEnv` helm value instead of the dedicated `http_proxy` to
reduce duplicated code.

Fixes #4

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.
