### PR TITLE
Auto-upgrade for cert-manager CRDs

### DIFF
--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -41,3 +41,8 @@ parameters:
         output_type: yaml
         input_paths:
           - cert-manager/component/main.jsonnet
+      - output_path: cert-manager/03_upgrade
+        input_type: jsonnet
+        output_type: yaml
+        input_paths:
+          - cert-manager/component/upgrade.jsonnet

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,5 +14,6 @@ parameters:
             class: 'nginx'
     images:
       kubectl:
-        image: quay.io/bitnami/kubectl
+        registry: quay.io
+        image: bitnami/kubectl
         tag: '1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576'

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,3 +12,7 @@ parameters:
         http01:
           ingress:
             class: 'nginx'
+    images:
+      kubectl:
+        image: quay.io/bitnami/kubectl
+        tag: '1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576'

--- a/component/upgrade.jsonnet
+++ b/component/upgrade.jsonnet
@@ -57,7 +57,7 @@ local job = kube.Job(name) {
         serviceAccountName: serviceAccount.metadata.name,
         containers_+: {
           patch_crds: kube.Container(name) {
-            image: std.join(':', [ params.images.kubectl.image, params.images.kubectl.tag ]),
+            image: '%s/%s:%s' % [ params.images.kubectl.registry, params.images.kubectl.image, params.images.kubectl.tag ],
             workingDir: '/export',
             command: [ 'sh' ],
             args: [ '-eu', '-c', upgradeScript ],

--- a/component/upgrade.jsonnet
+++ b/component/upgrade.jsonnet
@@ -1,0 +1,87 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.cert_manager;
+
+local crds = [
+  'certificaterequests.cert-manager.io',
+  'certificates.cert-manager.io',
+  'challenges.acme.cert-manager.io',
+  'clusterissuers.cert-manager.io',
+  'issuers.cert-manager.io',
+  'orders.acme.cert-manager.io',
+];
+
+local name = 'cert-manager-crd-upgrade';
+
+local addSyncWave = function(object) object {
+  metadata+: {
+    annotations+: {
+      'argocd.argoproj.io/sync-wave': '-10',
+    },
+  },
+};
+
+local upgradeScript = importstr './upgrade/patch-crds.sh';
+
+local role = kube.ClusterRole(name) {
+  rules: [
+    {
+      apiGroups: [ 'apiextensions.k8s.io' ],
+      resources: [ 'customresourcedefinitions' ],
+      verbs: [ 'get', 'patch' ],
+    },
+  ],
+};
+
+local serviceAccount = kube.ServiceAccount(name) {
+  metadata+: { namespace: params.namespace },
+};
+
+local roleBinding = kube.ClusterRoleBinding(name) {
+  subjects_: [ serviceAccount ],
+  roleRef_: role,
+};
+
+local job = kube.Job(name) {
+  metadata+: {
+    namespace: params.namespace,
+    annotations+: {
+      'argocd.argoproj.io/hook': 'Sync',
+      'argocd.argoproj.io/hook-delete-policy': 'HookSucceeded',
+    },
+  },
+  spec+: {
+    template+: {
+      spec+: {
+        serviceAccountName: serviceAccount.metadata.name,
+        containers_+: {
+          patch_crds: kube.Container(name) {
+            image: std.join(':', [ params.images.kubectl.image, params.images.kubectl.tag ]),
+            workingDir: '/export',
+            command: [ 'sh' ],
+            args: [ '-eu', '-c', upgradeScript ],
+            env: [
+              { name: 'CRDS_TO_PATCH', value: std.join(' ', crds) },
+            ],
+            volumeMounts: [
+              { name: 'export', mountPath: '/export' },
+            ],
+          },
+        },
+        volumes+: [
+          { name: 'export', emptyDir: {} },
+        ],
+      },
+    },
+  },
+};
+
+{
+  '00_upgrade': [
+    addSyncWave(role),
+    addSyncWave(serviceAccount),
+    addSyncWave(roleBinding),
+    addSyncWave(job),
+  ],
+}

--- a/component/upgrade/patch-crds.sh
+++ b/component/upgrade/patch-crds.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+for crd in ${CRDS_TO_PATCH}; do
+  exists=$(kubectl get crd "${crd}" --ignore-not-found)
+  if [ -z "$exists" ]; then
+    >&2 echo "WARNING: Skipping '${crd}': not found."
+    continue
+  fi
+  # Export and remove all `metadata` properties except `name`, `labels` and `annotations`
+  kubectl get crd "${crd}" -o json > "${crd}.json"
+  jq 'del(.status) | .metadata = (.metadata | {name, labels, annotations})' "${crd}.json" > "${crd}.patched.json"
+  # Apply the CRD again (this shouldn't change anything, except updating the annotation "kubectl.kubernetes.io/last-applied-configuration")
+  # You will also see some warnings in the output mentioning the annotation.
+  # This is expected and actually required.
+  kubectl apply -f "${crd}.patched.json"
+done

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v1-v2.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v1-v2.adoc
@@ -4,54 +4,11 @@ Version 2.x upgrades the underlying `cert-manager` Helm chart from `v0.x` to `v1
 There are some breaking changes in `cert-manager`.
 More information can be found https://github.com/jetstack/cert-manager/releases[in changelog on GitHub] and in the https://cert-manager.io/docs/installation/upgrading/[upgrade documentation].
 
-The upgrade is done with the following steps:
-
-. Compile Commodore catalog with `component-cert-manager` v2.x
-. Fix CRD upgrade
-. Verify cert-manager upgrade
-
-== Prerequisites
-
-. `commodore`
-. `kubectl` or `oc`
-. https://github.com/mikefarah/yq[`yq`] version 4 (alternatively, any editor works)
-
-== Upgrade
-
-. Compile and push cluster catalog with `component-cert-manager` v2.x
-
-. Fix CRD upgrade
-+
-[source,bash]
-----
-cat <<'EOF' > cert-manager-prepare-merge-crds.sh
-#!/bin/sh
-
-set -euo pipefail
-
-for crd in certificaterequests.cert-manager.io certificates.cert-manager.io challenges.acme.cert-manager.io clusterissuers.cert-manager.io issuers.cert-manager.io orders.acme.cert-manager.io; do
-  # Get CRD definition in YAML
-  kubectl get crd "${crd}" -o yaml > "${crd}.yaml"
-  # Remove all metadata properties except `metadata.name`
-  yq -i eval 'del(.status) | del(.metadata) | .metadata.name += "'${crd}'"' "${crd}.yaml"
-  # Apply the CRD again (this shouldn't change anything, except updating the annotation "kubectl.kubernetes.io/last-applied-configuration")
-  # You will also see some warnings in the output mentioning the annotation.
-  # This is expected and actually required.
-  kubectl apply -f "${crd}.yaml"
-done
-EOF
-
-sh cert-manager-prepare-merge-crds.sh
-----
+This upgrade should require no manual steps, but it's recommended to verify the upgrade.
 
 == Verify cert-manager and certificates
 
 . Verify successful sync and health status in ArgoCD
-+
-[NOTE]
-====
-If ArgoCD sync is marked as failed it may be required to trigger another sync.
-====
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
This PR automates the [manual update process](https://github.com/projectsyn/component-cert-manager/blob/4b838470ce7c5ae90028d2a111164274b093e3e6/docs/modules/ROOT/pages/how-tos/upgrade-v1-v2.adoc#upgrade-component-cert-manager-from-v1x-to-v2x) introduced by #16.

The upgrade is accomplished by an [ArgoCD hook](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/) executing in a [sync wave](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) before the CRDs are applied.

<details>
  <summary>Local job testing without Argo</summary>

```sh
kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml

make test
kubectl create ns syn-cert-manager
kubectl apply -f compiled/cert-manager/cert-manager/03_upgrade/00_upgrade.yaml

kubectl delete ns syn-cert-manager
kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
```

</details>
