### PR TITLE
Add support for configuring solver secrets

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,6 +12,7 @@ parameters:
         http01:
           ingress:
             class: 'nginx'
+    secrets: {}
     images:
       kubectl:
         registry: quay.io

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -70,6 +70,19 @@ A dictionary holding the solvers for the default cluster issuers.
 
 See https://cert-manager.io/docs/configuration/acme/#configuration for configurable parameters.
 
+== `secrets`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+A dictionary holding secrets for DNS01 solvers.
+Each key in the dictionary is used as the name of a secret.
+The value of the key is merged directly into an empty Kubernetes `Secret` resource.
+By default, secrets are created in the namespace in which cert-manager is deployed.
+
+See the https://cert-manager.io/docs/configuration/acme/dns01/[cert-manager documentation] for DNS01 solvers which are supported by cert-manager.
+
 == Example
 
 [source,yaml]
@@ -82,4 +95,15 @@ solvers:
           metadata:
             labels:
               app: "solver"
+  dns01:
+    acmeDNS:
+      accountSecretRef:
+        name: acmedns
+          key: acmedns.json
+        host: auth.example.com
+
+secrets:
+  acmedns:
+    stringData:
+      acmedns.json: ?{vaultkv:${cluster:tenant}/${cluster:name}/acmedns}
 ----


### PR DESCRIPTION
Add parameter `secrets` which allows users to configure secrets for DNS01 solvers, such as acme-dns.

Fixes #24

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
