### PR TITLE
Support for self-registration on an acme-dns instance

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -13,6 +13,11 @@ parameters:
           ingress:
             class: 'nginx'
     secrets: {}
+    acme_dns_api: {}
+    # endpoint: acme-dns-api.example.com
+    # user: dns_api_registration_user
+    # password: dns_api_registration_password
+    # domains: [ "cluster.example.com", "apps.cluster.example.com" ]
     images:
       kubectl:
         registry: quay.io

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,7 +16,7 @@ parameters:
     acme_dns_api: {}
     # acme_dns_api:
     #   endpoint: acme-dns-api.example.com
-    #   user: dns_api_registration_user
+    #   username: dns_api_registration_user
     #   password: dns_api_registration_password
     #   fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
     images:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,7 +17,7 @@ parameters:
     # endpoint: acme-dns-api.example.com
     # user: dns_api_registration_user
     # password: dns_api_registration_password
-    # domains: [ "cluster.example.com", "apps.cluster.example.com" ]
+    # fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
     images:
       kubectl:
         registry: quay.io

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,10 +14,11 @@ parameters:
             class: 'nginx'
     secrets: {}
     acme_dns_api: {}
-    # endpoint: acme-dns-api.example.com
-    # user: dns_api_registration_user
-    # password: dns_api_registration_password
-    # fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
+    # acme_dns_api:
+    #   endpoint: acme-dns-api.example.com
+    #   user: dns_api_registration_user
+    #   password: dns_api_registration_password
+    #   fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
     images:
       kubectl:
         registry: quay.io

--- a/component/acme-dns-scripts/check.sh
+++ b/component/acme-dns-scripts/check.sh
@@ -7,8 +7,8 @@ set -e
 username=
 password=
 subdomain=
-acmedns_config=$(jq -r --argjson domains "${ACME_DNS_DOMAINS}" '
-    .[$domains[0]]
+acmedns_config=$(jq -r --argjson fqdns "${ACME_DNS_FQDNS}" '
+    .[$fqdns[0]]
     | "username=\(.username) password=\(.password) subdomain=\(.subdomain)"
   ' "${CONFIG_PATH}/acmedns.json")
 # This overrides the empty variables declared above

--- a/component/acme-dns-scripts/check.sh
+++ b/component/acme-dns-scripts/check.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+# Extract acme-dns client config from mounted secret file with `jq` and inject
+# as variables into the script environment with `eval`.
+username=
+password=
+subdomain=
+acmedns_config=$(jq -r --argjson domains "${ACME_DNS_DOMAINS}" '
+    .[$domains[0]]
+    | "username=\(.username) password=\(.password) subdomain=\(.subdomain)"
+  ' "${CONFIG_PATH}/acmedns.json")
+# This overrides the empty variables declared above
+eval "${acmedns_config}"
+
+reregister=
+if ! curl \
+  -H"X-Api-User: ${username}" \
+  -H"X-Api-Key: ${password}" \
+  -d '{
+    "subdomain": "'"${subdomain}"'",
+    "txt": "___self___verify___client___credentials____"
+  }' "${ACME_DNS_API}"/update; then
+  echo "Failed to update record... trying reregistration"
+  reregister="yes"
+fi
+
+if [ -n "${reregister}" ]; then
+  "${SCRIPTS_PATH}/register.sh" force
+fi

--- a/component/acme-dns-scripts/register.sh
+++ b/component/acme-dns-scripts/register.sh
@@ -25,14 +25,14 @@ if ! [ -f /etc/scripts/acmedns.json ] \
   client_secret=$(jq -n \
     --argjson orig_secret "${orig_secret}" \
     --argjson reg "${reg}" \
-    --argjson domains "${ACME_DNS_DOMAINS}" \
+    --argjson fqdns "${ACME_DNS_FQDNS}" \
     --arg client_secret_name "${CLIENT_SECRET_NAME}" \
     --arg namespace "${NAMESPACE}" \
     '($orig_secret
       |del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")
      ) + {
       "stringData": {
-        "acmedns.json": (reduce $domains[] as $d ({}; . + { ($d): $reg })) | tojson
+        "acmedns.json": (reduce $fqdns[] as $d ({}; . + { ($d): $reg })) | tojson
       }
     }')
 

--- a/component/acme-dns-scripts/register.sh
+++ b/component/acme-dns-scripts/register.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+
+readonly force_register="${1}"
+
+if ! [ -f /etc/scripts/acmedns.json ] \
+  || [ -n "${force_register}" ]; then
+
+  reg=$(curl -XPOST -u "${REG_USERNAME}:${REG_PASSWORD}" \
+    "${ACME_DNS_API}/register")
+  # Create acme-dns-client secret for provided domain names.
+  # Required format for acmedns.json in `stringData`:
+  # {
+  #   "example.com": { registration output },
+  #   "example.org": { registration output }
+  # }
+  client_secret=$(jq -n \
+    --argjson reg "${reg}" \
+    --argjson domains "${ACME_DNS_DOMAINS}" \
+    --arg client_secret_name "${CLIENT_SECRET_NAME}" \
+    --arg namespace "${NAMESPACE}" \
+    '{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "type": "Opaque",
+      "metadata": {
+        "name": $client_secret_name,
+        "namespace": $namespace,
+      },
+      "stringData": {
+        "acmedns.json": (reduce $domains[] as $d ({}; . + { ($d): $reg })) | tojson
+      }
+    }')
+
+  echo "${client_secret}" >"${HOME}/secret.yaml"
+  # Use kubectl apply as the empty secret is created by ArgoCD
+  kubectl apply -f "${HOME}/secret.yaml"
+fi

--- a/component/acme-dns-scripts/register.sh
+++ b/component/acme-dns-scripts/register.sh
@@ -3,16 +3,18 @@
 set -e
 
 readonly force_register="${1}"
+readonly client_creds_file="${CONFIG_PATH}/acmedns.json"
 
 readonly orig_secret="$(kubectl -n "${NAMESPACE}" \
   get secret "${CLIENT_SECRET_NAME}" -ojson)"
 
 reg_auth_args=
 if [ -n "${REG_USERNAME}" ]; then
-  reg_auth_args="-u\"${REG_USERNAME}:${REG_PASSWORD}\""
+  reg_auth_args="-u${REG_USERNAME}:${REG_PASSWORD}"
 fi
 
-if ! [ -f /etc/scripts/acmedns.json ] \
+
+if ! [ -f "${client_creds_file}" ] \
   || [ -n "${force_register}" ]; then
 
   reg=$(curl -XPOST "${reg_auth_args}" "${ACME_DNS_API}/register")
@@ -39,4 +41,6 @@ if ! [ -f /etc/scripts/acmedns.json ] \
   echo "${client_secret}" >"${HOME}/secret.json"
   # Use kubectl apply as the empty secret is created by ArgoCD
   kubectl apply -f "${HOME}/secret.json"
+else
+  echo "Client credentials config '${client_creds_file}' already exists."
 fi

--- a/component/acme-dns-scripts/register.sh
+++ b/component/acme-dns-scripts/register.sh
@@ -7,11 +7,15 @@ readonly force_register="${1}"
 readonly orig_secret="$(kubectl -n "${NAMESPACE}" \
   get secret "${CLIENT_SECRET_NAME}" -ojson)"
 
+reg_auth_args=
+if [ -n "${REG_USERNAME}" ]; then
+  reg_auth_args="-u\"${REG_USERNAME}:${REG_PASSWORD}\""
+fi
+
 if ! [ -f /etc/scripts/acmedns.json ] \
   || [ -n "${force_register}" ]; then
 
-  reg=$(curl -XPOST -u "${REG_USERNAME}:${REG_PASSWORD}" \
-    "${ACME_DNS_API}/register")
+  reg=$(curl -XPOST "${reg_auth_args}" "${ACME_DNS_API}/register")
   # Create acme-dns-client secret for provided domain names.
   # Required format for acmedns.json in `stringData`:
   # {

--- a/component/acme-dns.libsonnet
+++ b/component/acme-dns.libsonnet
@@ -99,7 +99,7 @@ local scriptPodSpec(name, script) = {
         SCRIPTS_PATH: mountpaths.scripts,
         CLIENT_SECRET_NAME: clientSecret.metadata.name,
         ACME_DNS_API: acme_dns_api.endpoint,
-        ACME_DNS_DOMAINS: '%s' % [ acme_dns_api.domains ],
+        ACME_DNS_FQDNS: '%s' % [ acme_dns_api.fqdns ],
       },
       envFrom: std.prune([
         if has_registration_secret then {

--- a/component/acme-dns.libsonnet
+++ b/component/acme-dns.libsonnet
@@ -1,0 +1,199 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.cert_manager;
+
+local acme_dns_api = params.acme_dns_api;
+
+local has_registration_secret = std.objectHas(acme_dns_api, 'username');
+local registrationSecret =
+  if has_registration_secret then
+    kube.Secret('acme-dns-register') {
+      metadata+: {
+        namespace: params.namespace,
+      },
+      stringData: {
+        REG_USERNAME: acme_dns_api.username,
+        REG_PASSWORD: acme_dns_api.password,
+      },
+    };
+
+local jobnames = {
+  registration: 'register-acme-dns-client',
+  check: 'check-acme-dns-client',
+};
+local clientSecret =
+  kube.Secret('acme-dns-client') {
+    metadata+: {
+      annotations+: {
+        'cert-manager.syn.tools/managed-by':
+          'The contents of this secret are managed by resources Job/%s and CronJob/%s' % [
+            jobnames.registration,
+            jobnames.check,
+          ],
+      },
+      namespace: params.namespace,
+    },
+  };
+
+local mountpaths = {
+  acmednsjson: '/etc/acme-dns',
+  scripts: '/scripts',
+};
+local scriptConfigmap =
+  kube.ConfigMap('register-acme-dns-client') {
+    metadata+: {
+      namespace: params.namespace,
+    },
+    data: {
+      'register.sh': importstr 'acme-dns-scripts/register.sh',
+      'check.sh': importstr 'acme-dns-scripts/check.sh',
+    },
+  };
+
+local scriptServiceAccount = kube.ServiceAccount('acme-dns') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+};
+
+local scriptRole = kube.Role('acme-dns-secret-editor') {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'secrets' ],
+      verbs: [ 'create', 'patch', 'get' ],
+    },
+  ],
+};
+
+local scriptRoleBinding = kube.RoleBinding('acme-dns-secret-editor') {
+  subjects_: [ scriptServiceAccount ],
+  roleRef_: scriptRole,
+};
+
+local scriptPodSpec(name, script) = {
+  containers_+: {
+    c: kube.Container(name) {
+      image: '%s/%s:%s' % [
+        params.images.kubectl.registry,
+        params.images.kubectl.image,
+        params.images.kubectl.tag,
+      ],
+      workingDir: '/home/acme-dns',
+      command: [ '/scripts/%s' % script ],
+      env_: {
+        HOME: '/home/acme-dns',
+        NAMESPACE: {
+          fieldRef: {
+            fieldPath: 'metadata.namespace',
+          },
+        },
+        // Script config parameters
+        CONFIG_PATH: mountpaths.acmednsjson,
+        SCRIPTS_PATH: mountpaths.scripts,
+        CLIENT_SECRET_NAME: clientSecret.metadata.name,
+        ACME_DNS_API: acme_dns_api.endpoint,
+        ACME_DNS_DOMAINS: '%s' % [ acme_dns_api.domains ],
+      },
+      envFrom: std.prune([
+        if has_registration_secret then {
+          secretRef: {
+            name: registrationSecret.metadata.name,
+          },
+        },
+      ]),
+      volumeMounts_: {
+        acmedns_client_secret: {
+          mountPath: mountpaths.acmednsjson,
+          readOnly: true,
+        },
+        home: {
+          mountPath: '/home/acme-dns',
+        },
+        scripts: {
+          mountPath: mountpaths.scripts,
+        },
+      },
+    },
+  },
+  serviceAccountName: scriptServiceAccount.metadata.name,
+  volumes_: {
+    acmedns_client_secret: {
+      secret: {
+        secretName: clientSecret.metadata.name,
+      },
+    },
+    home: {
+      emptyDir: {},
+    },
+    scripts: {
+      configMap: {
+        // 0700
+        defaultMode: 448,
+        name: scriptConfigmap.metadata.name,
+      },
+    },
+  },
+};
+
+local registrationJob =
+  kube.Job(jobnames.registration) {
+    metadata+: {
+      namespace: params.namespace,
+    },
+    spec+: {
+      template+: {
+        spec+: scriptPodSpec('register-client', 'register.sh'),
+      },
+    },
+  };
+
+// Generate randomize cronjob schedule between midnight and 2am
+local scope = '%(tenant)s/%(name)s' % inv.parameters.cluster;
+local totalminute = std.foldl(
+  function(x, y) x + y, std.encodeUTF8(std.md5(scope)), 0
+) % 120;
+local hour = totalminute / 60;
+local minute = totalminute % 60;
+
+local clientcheckCronjob =
+  kube.CronJob(jobnames.check) {
+    metadata+: {
+      namespace: params.namespace,
+    },
+    spec+: {
+      jobTemplate+: {
+        spec+: {
+          template+: {
+            spec+: scriptPodSpec('check-client', 'check.sh'),
+          },
+        },
+      },
+      schedule: '%d %d * * *' % [ minute, hour ],
+    },
+  };
+
+if std.objectHas(acme_dns_api, 'endpoint') then
+  {
+    manifests: std.filter(
+      function(it) it != null,
+      [
+        scriptServiceAccount,
+        scriptRole,
+        scriptRoleBinding,
+        scriptConfigmap,
+        registrationSecret,
+        clientSecret,
+        registrationJob,
+        clientcheckCronjob,
+      ]
+    ),
+  }
+else
+  {}

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -3,7 +3,20 @@ local inv = kap.inventory();
 local params = inv.parameters.cert_manager;
 local argocd = import 'lib/argocd.libjsonnet';
 
-local app = argocd.App('cert-manager', params.namespace);
+local app = argocd.App('cert-manager', params.namespace) {
+  spec+: {
+    ignoreDifferences: [
+      {
+        kind: 'Secret',
+        name: 'acme-dns-client',
+        namespace: params.namespace,
+        jsonPointers: [
+          '/data',
+        ],
+      },
+    ],
+  },
+};
 
 {
   'cert-manager': app,

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,6 +50,8 @@ local secrets = [
   for s in std.objectFields(params.secrets)
 ];
 
+local acmedns = import 'acme-dns.libsonnet';
+
 {
   '00_clusterissuer': [
     letsencrypt_staging,
@@ -57,4 +59,6 @@ local secrets = [
   ],
   [if std.length(secrets) > 0 then '10_solver_secrets']:
     secrets,
+  [if std.objectHas(acmedns, 'manifests') then '20_acme_dns']:
+    acmedns.manifests,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,34 +1,32 @@
+local cm = import 'lib/cert-manager.libsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+
 local inv = kap.inventory();
 local params = inv.parameters.cert_manager;
 
 local letsencrypt_email = inv.parameters.cert_manager.letsencrypt_email;
 
-local letsencrypt_staging = {
-  apiVersion: 'cert-manager.io/v1alpha2',
-  kind: 'ClusterIssuer',
-  metadata: {
-    name: 'letsencrypt-staging',
-  },
-  spec: {
-    acme: {
-      email: letsencrypt_email,
-      server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
-      privateKeySecretRef: {
-        name: 'letsencrypt-staging',
+local letsencrypt_staging =
+  cm.clusterIssuer('letsencrypt-staging') {
+    spec: {
+      acme: {
+        email: letsencrypt_email,
+        server: 'https://acme-staging-v02.api.letsencrypt.org/directory',
+        privateKeySecretRef: {
+          name: 'letsencrypt-staging',
+        },
+        solvers: std.prune([
+          params.solvers[s]
+          for s in std.objectFields(params.solvers)
+        ]),
       },
-      solvers: std.prune([
-        params.solvers[s]
-        for s in std.objectFields(params.solvers)
-      ]),
     },
-  },
-};
+  };
 
 local letsencrypt_production = letsencrypt_staging {
-  metadata: {
+  metadata+: {
     name: 'letsencrypt-production',
   },
   spec+: {

--- a/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
+++ b/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
@@ -1,0 +1,50 @@
+= acme-dns self-registration
+
+The component provides support to register a client on an acme-dns instance through parameter xref:references/parameters.adoc#_acme_dns_api[`acme_dns_api`].
+
+This page explains how the self-registraion mechanism works in detail.
+The mechanism consists of two parts: registration and checking.
+
+== Registration
+
+To register a client, the component creates a Kubernetes `Job` in the cert-manager namespace (component parameter `namespace`).
+The Job runs a shell script which registers a new client on the configured acme-dns instance (parameter `acme_dns_api.endpoint`).
+If parameters `amce_dns_api.username` and `acme_dns_api.password` are provided, the job registers a new client using HTTP basic authentication.
+
+If registration is successful, the Job updates the secret `acme-dns-client` to contain a key `acmedns.json` holding the JSON returned by the acme-dns `/register` endpoint in the following form:
+
+[source,json]
+----
+{
+  "cluster.example.com": { <1>
+    "username":"3a33a0ef-b617-418d-97a4-13cf1cd6b67a",
+    "password":"<redacted>",
+    "fulldomain":"9165e46c-7bc8-4b00-aa0d-d40413271434.acme-dns.example.com",
+    "subdomain":"9165e46c-7bc8-4b00-aa0d-d40413271434",
+    "allowfrom":[]
+  },
+  "apps.cluster.example.com": { <1>
+    "username":"3a33a0ef-b617-418d-97a4-13cf1cd6b67a",
+    "password":"<redacted>",
+    "fulldomain":"9165e46c-7bc8-4b00-aa0d-d40413271434.acme-dns.example.com",
+    "subdomain":"9165e46c-7bc8-4b00-aa0d-d40413271434",
+    "allowfrom":[]
+  }
+}
+----
+<1> The component uses the entries in parameter `acme_dns_api.domains` as keys in the JSON object.
+The value for each key is the JSON that the call to the acme-dns `/register` endpoint returns.
+
+Each key in the object corresponds to a domain for which cert-manager will use the acme-dns instance to solve DNS01 challenges.
+The secret `acme-dns-client` can then be used to configure a DNS01 solver on cert-manager `Issuer` and `ClusterIssuer` resources.
+
+== Checking
+
+The component creates a Kubernetes `CronJob` which checks that the acme-dns client credentials are valid every 24h.
+The component randomizes the schedule for the cronjob to have the check run between midnight and 2 AM.
+
+The check is currently implemented as a shell script which tries to update a record on the acme-dns instance using the credentials in secret `acme-dns-client`.
+The update of the TXT record is implemented as a curl call to the acme-dns `/update` endpoint.
+If the curl call fails, the script triggers a reregistration of the client.
+
+NOTE: The check script currently doesn't verify that the update to the TXT record is actually propagated through DNS.

--- a/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
+++ b/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
@@ -16,7 +16,7 @@ If registration is successful, the Job updates the secret `acme-dns-client` to c
 [source,json]
 ----
 {
-  "cluster.example.com": { <1>
+  "api.cluster.example.com": { <1>
     "username":"3a33a0ef-b617-418d-97a4-13cf1cd6b67a",
     "password":"<redacted>",
     "fulldomain":"9165e46c-7bc8-4b00-aa0d-d40413271434.acme-dns.example.com",
@@ -32,7 +32,7 @@ If registration is successful, the Job updates the secret `acme-dns-client` to c
   }
 }
 ----
-<1> The component uses the entries in parameter `acme_dns_api.domains` as keys in the JSON object.
+<1> The component uses the entries in parameter `acme_dns_api.fqdns` as keys in the JSON object.
 The value for each key is the JSON that the call to the acme-dns `/register` endpoint returns.
 
 Each key in the object corresponds to a domain for which cert-manager will use the acme-dns instance to solve DNS01 challenges.

--- a/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
+++ b/docs/modules/ROOT/pages/explanations/acme-dns-self-registration.adoc
@@ -2,7 +2,7 @@
 
 The component provides support to register a client on an acme-dns instance through parameter xref:references/parameters.adoc#_acme_dns_api[`acme_dns_api`].
 
-This page explains how the self-registraion mechanism works in detail.
+This page explains how the self-registration mechanism works in detail.
 The mechanism consists of two parts: registration and checking.
 
 == Registration

--- a/docs/modules/ROOT/pages/how-tos/dns01.adoc
+++ b/docs/modules/ROOT/pages/how-tos/dns01.adoc
@@ -28,12 +28,15 @@ parameters:
       endpoint: https://acme-dns-api.example.com <1>
       username: acme-dns <2>
       password: ?{vaultkv:${cluster:tenant}/${cluster:name}/cert-manager/acme-dns-password} <2>
-      domains: <3>
+      fqdns: <3>
         - cluster.example.com
 ----
 <1> The HTTP API of the acme-dns instance
 <2> The HTTP basic auth username and password for the acme-dns instance (optional)
-<3> The list of domains that you want to use acme-dns challenges for.
+<3> The list of FQDNs that you want to use acme-dns challenges for.
+Note that the entries must match FQDNs for which you want to use acme-dns challenges exactly.
+With this configuration, cert-manager will only present DNS01 challenges for certificates with dnsNames `cluster.example.com` or `*.cluster.example.com`.
+In particular, cert-manager won't present DNS01 challenges for any subdomains of `cluster.example.com` with this configuration.
 +
 This configuration creates a secret `acme-dns-client` with the acme-dns client configuration in key `acmedns.json` in the cert-manager namespace.
 

--- a/docs/modules/ROOT/pages/how-tos/dns01.adoc
+++ b/docs/modules/ROOT/pages/how-tos/dns01.adoc
@@ -1,0 +1,82 @@
+= Using DNS01 challenges
+
+Usually DNS01 challenges are required for the following scenarios:
+* Issuing Let's Encrypt wildcard certificates
+* Issuing certificates for services which have a public DNS name, but aren't reachable on the internet
+
+This how-to shows you how to configure the `letsencrypt-staging` and `letsencrypt-production` cluster issuers managed by the component for DNS01 challenges.
+
+This how-to assumes that you have access to an acme-dns instance.
+You can manage your own acme-dns instance with component xref:acme-dns:ROOT:index.adoc[acme-dns].
+
+= Prerequisites
+
+* Access to an acme-dns instance
+* A domain for which you can create `CNAME` records
+* You can compile cluster catalogs locally
+
+== Setup
+
+. Configure the component to register itself on an acme-dns instance.
+Add the following configuration to your cluster or global configuration.
++
+[source,yaml]
+----
+parameters:
+  cert_manager:
+    acme_dns_api:
+      endpoint: https://acme-dns-api.example.com <1>
+      username: acme-dns <2>
+      password: ?{vaultkv:${cluster:tenant}/${cluster:name}/cert-manager/acme-dns-password} <2>
+      domains: <3>
+        - cluster.example.com
+----
+<1> The HTTP API of the acme-dns instance
+<2> The HTTP basic auth username and password for the acme-dns instance (optional)
+<3> The list of domains that you want to use acme-dns challenges for.
++
+This configuration creates a secret `acme-dns-client` with the acme-dns client configuration in key `acmedns.json` in the cert-manager namespace.
+
+. Configure the DNS01 solver
++
+[source,yaml]
+----
+parameters:
+  cert_manager:
+    solvers:
+      nginx_http01: null <1>
+      dns01:
+        acmeDNS:
+          host: https://acme-dns-api.example.com <2>
+          accountSecretRef: <3>
+            name: acme-dns-client
+            key: acmedns.json
+----
+<1> Disable the default `nginx_http01` solver
+<2> The HTTP API of the acme-dns instance.
+This should match parameter `acme_dns_api.endpoint`.
+<3> The account secret for the acme-dns instance.
+Use the values shown here to use the client secret which is created by the configuration from the previous step.
+
+. Compile and push the cluster catalog to apply your configuration.
+
+. Setup CNAME records to point acme challenges to acme-dns on your cluster's domain after the registration job has completed.
++
+.Extract CNAME target from the acme-dns-client secret
+[source,shell]
+----
+$ kubectl -n syn-cert-manager get secret acme-dns-client \
+    -ojsonpath='{.data.acmedns\.json} | \
+    base64 -d | \
+    jq -r '[.[]][0].fulldomain'
+9165e46c-7bc8-4b00-aa0d-d40413271434.acme-dns.example.com
+----
++
+.Add the following record to your cluster's DNS zone
+[source,dns]
+----
+$ORIGIN cluster.example.com <1>
+_acme-challenge IN CNAME 9165e46c-7bc8-4b00-aa0d-d40413271434.acme-dns.example.com. <2>
+----
+<1> This snippet assumes that the cluster's DNS zone is `cluster.example.com`.
+<2> Replace `<UUID>.acme-dns.example.com` with the output of the `kubectl` command.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -83,6 +83,27 @@ By default, secrets are created in the namespace in which cert-manager is deploy
 
 See the https://cert-manager.io/docs/configuration/acme/dns01/[cert-manager documentation] for DNS01 solvers which are supported by cert-manager.
 
+== `acme_dns_api`
+
+[horizontal]
+type:: dictionary
+keys:: `endpoint`, `username`, `password`, `domains`
+default:: `{}`
+
+The component sets up a Job and Cronjob to register and check acme-dns client credentials if key `endpoint` is present in this parameter.
+For a detailed explanation of how the self-registration works, see the xref:explanations/acme-dns-self-registration.adoc[acme-dns self-registraion] documentation.
+
+If key `endpoint` is present, the component expects that the other keys listed above are also present. The keys have the following meaning:
+
+`endpoint`:: The HTTP API endpoint of the acme-dns instance
+`username`:: The HTTP basic authorization username for the acme-dns instance `/register` endpoint
+`password`:: The HTTP basic authorization password for the acme-dns instance `/register` endpoint.
+We strongly recommend specifying the password as a Vault secret reference.
+`domains`:: A list of domains for which the acme-dns instance can be used to solve DNS01 challenges.
+This list must contain at least one entry.
+
+TIP: See xref:how-tos/dns01.acme[Using DNS01 challenges] for instructions to setup and use the acme-dns self-registration mechanism.
+
 == Example
 
 [source,yaml]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -91,7 +91,7 @@ keys:: `endpoint`, `username`, `password`, `fqdns`
 default:: `{}`
 
 The component sets up a Job and Cronjob to register and check acme-dns client credentials if key `endpoint` is present in this parameter.
-For a detailed explanation of how the self-registration works, see the xref:explanations/acme-dns-self-registration.adoc[acme-dns self-registraion] documentation.
+For a detailed explanation of how the self-registration works, see the xref:explanations/acme-dns-self-registration.adoc[acme-dns self-registration] documentation.
 
 If key `endpoint` is present, the component expects that the other keys listed above are also present. The keys have the following meaning:
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -87,7 +87,7 @@ See the https://cert-manager.io/docs/configuration/acme/dns01/[cert-manager docu
 
 [horizontal]
 type:: dictionary
-keys:: `endpoint`, `username`, `password`, `domains`
+keys:: `endpoint`, `username`, `password`, `fqdns`
 default:: `{}`
 
 The component sets up a Job and Cronjob to register and check acme-dns client credentials if key `endpoint` is present in this parameter.
@@ -99,10 +99,16 @@ If key `endpoint` is present, the component expects that the other keys listed a
 `username`:: The HTTP basic authorization username for the acme-dns instance `/register` endpoint
 `password`:: The HTTP basic authorization password for the acme-dns instance `/register` endpoint.
 We strongly recommend specifying the password as a Vault secret reference.
-`domains`:: A list of domains for which the acme-dns instance can be used to solve DNS01 challenges.
+`fqdns`:: A list of FQDNs for which the acme-dns instance can be used to solve DNS01 challenges.
 This list must contain at least one entry.
 
 TIP: See xref:how-tos/dns01.acme[Using DNS01 challenges] for instructions to setup and use the acme-dns self-registration mechanism.
+
+[NOTE]
+====
+The entries in `fqdns` must be exact matches the FQDNs for which DNS01 challenges should be presented.
+The only flexibility is that cert-manager will present a DNS01 challenge for the wildcard FQDN `*.example.com`, if `example.com` is listed in `fqdns`.
+====
 
 == Example
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,6 +1,7 @@
 * xref:index.adoc[Home]
 
 .How-tos
+* xref:how-tos/dns01.adoc[Using DNS01 challenges]
 * xref:how-tos/http01-ocp.adoc[Use HTTP01 solver on OpenShift]
 * xref:how-tos/upgrade-v1-v2.adoc[Upgrade from `v1.x` to `v2.x`]
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -7,3 +7,6 @@
 
 .Technical reference
 * xref:references/parameters.adoc[Parameters]
+
+.Explanations
+* xref:explanations/acme-dns-self-registration.adoc[acme-dns self-registration]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -5,6 +5,6 @@ parameters:
       endpoint: acme-dns-api.example.com
       username: acme-dns
       password: ?{vaultkv:${cluster:tenant}/${cluster:name}/cert-manager/acme-dns-register-password}
-      domains:
+      fqdns:
         - example.com
         - apps.example.com

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,10 @@
 parameters:
   cert_manager:
     letsencrypt_email: test@syn.tools
+    acme_dns_api:
+      endpoint: acme-dns-api.example.com
+      username: acme-dns
+      password: ?{vaultkv:${cluster:tenant}/${cluster:name}/cert-manager/acme-dns-register-password}
+      domains:
+        - example.com
+        - apps.example.com

--- a/tests/golden/defaults/cert-manager/apps/cert-manager.yaml
+++ b/tests/golden/defaults/cert-manager/apps/cert-manager.yaml
@@ -1,0 +1,7 @@
+spec:
+  ignoreDifferences:
+    - jsonPointers:
+        - /data
+      kind: Secret
+      name: acme-dns-client
+      namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/00_clusterissuer.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/00_clusterissuer.yaml
@@ -1,6 +1,9 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations: {}
+  labels:
+    name: letsencrypt-staging
   name: letsencrypt-staging
 spec:
   acme:
@@ -13,9 +16,12 @@ spec:
           ingress:
             class: nginx
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  annotations: {}
+  labels:
+    name: letsencrypt-production
   name: letsencrypt-production
 spec:
   acme:

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -1,0 +1,254 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: acme-dns
+  name: acme-dns
+  namespace: syn-cert-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: acme-dns-secret-editor
+  name: acme-dns-secret-editor
+  namespace: syn-cert-manager
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - create
+      - patch
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: acme-dns-secret-editor
+  name: acme-dns-secret-editor
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: acme-dns-secret-editor
+subjects:
+  - kind: ServiceAccount
+    name: acme-dns
+    namespace: syn-cert-manager
+---
+apiVersion: v1
+data:
+  check.sh: "#!/bin/sh\n\nset -e\n\n# Extract acme-dns client config from mounted\
+    \ secret file with `jq` and inject\n# as variables into the script environment\
+    \ with `eval`.\nusername=\npassword=\nsubdomain=\nacmedns_config=$(jq -r --argjson\
+    \ domains \"${ACME_DNS_DOMAINS}\" '\n    .[$domains[0]]\n    | \"username=\\(.username)\
+    \ password=\\(.password) subdomain=\\(.subdomain)\"\n  ' \"${CONFIG_PATH}/acmedns.json\"\
+    )\n# This overrides the empty variables declared above\neval \"${acmedns_config}\"\
+    \n\nreregister=\nif ! curl \\\n  -H\"X-Api-User: ${username}\" \\\n  -H\"X-Api-Key:\
+    \ ${password}\" \\\n  -d '{\n    \"subdomain\": \"'\"${subdomain}\"'\",\n    \"\
+    txt\": \"___self___verify___client___credentials____\"\n  }' \"${ACME_DNS_API}\"\
+    /update; then\n  echo \"Failed to update record... trying reregistration\"\n \
+    \ reregister=\"yes\"\nfi\n\nif [ -n \"${reregister}\" ]; then\n  \"${SCRIPTS_PATH}/register.sh\"\
+    \ force\nfi\n"
+  register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nif ! [\
+    \ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\" ]; then\n\
+    \n  reg=$(curl -XPOST -u \"${REG_USERNAME}:${REG_PASSWORD}\" \\\n    \"${ACME_DNS_API}/register\"\
+    )\n  # Create acme-dns-client secret for provided domain names.\n  # Required\
+    \ format for acmedns.json in `stringData`:\n  # {\n  #   \"example.com\": { registration\
+    \ output },\n  #   \"example.org\": { registration output }\n  # }\n  client_secret=$(jq\
+    \ -n \\\n    --argjson reg \"${reg}\" \\\n    --argjson domains \"${ACME_DNS_DOMAINS}\"\
+    \ \\\n    --arg client_secret_name \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace\
+    \ \"${NAMESPACE}\" \\\n    '{\n      \"apiVersion\": \"v1\",\n      \"kind\":\
+    \ \"Secret\",\n      \"type\": \"Opaque\",\n      \"metadata\": {\n        \"\
+    name\": $client_secret_name,\n        \"namespace\": $namespace,\n      },\n \
+    \     \"stringData\": {\n        \"acmedns.json\": (reduce $domains[] as $d ({};\
+    \ . + { ($d): $reg })) | tojson\n      }\n    }')\n\n  echo \"${client_secret}\"\
+    \ >\"${HOME}/secret.yaml\"\n  # Use kubectl apply as the empty secret is created\
+    \ by ArgoCD\n  kubectl apply -f \"${HOME}/secret.yaml\"\nfi\n"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: register-acme-dns-client
+  name: register-acme-dns-client
+  namespace: syn-cert-manager
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: acme-dns-register
+  name: acme-dns-register
+  namespace: syn-cert-manager
+stringData:
+  REG_PASSWORD: t-silent-test-1234/c-green-test-1234/cert-manager/acme-dns-register-password
+  REG_USERNAME: acme-dns
+type: Opaque
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations:
+    cert-manager.syn.tools/managed-by: The contents of this secret are managed by
+      resources Job/register-acme-dns-client and CronJob/check-acme-dns-client
+  labels:
+    name: acme-dns-client
+  name: acme-dns-client
+  namespace: syn-cert-manager
+type: Opaque
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {}
+  labels:
+    name: register-acme-dns-client
+  name: register-acme-dns-client
+  namespace: syn-cert-manager
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: register-acme-dns-client
+    spec:
+      containers:
+        - args: []
+          command:
+            - /scripts/register.sh
+          env:
+            - name: ACME_DNS_API
+              value: acme-dns-api.example.com
+            - name: ACME_DNS_DOMAINS
+              value: '["example.com", "apps.example.com"]'
+            - name: CLIENT_SECRET_NAME
+              value: acme-dns-client
+            - name: CONFIG_PATH
+              value: /etc/acme-dns
+            - name: HOME
+              value: /home/acme-dns
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SCRIPTS_PATH
+              value: /scripts
+          envFrom:
+            - secretRef:
+                name: acme-dns-register
+          image: quay.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
+          imagePullPolicy: IfNotPresent
+          name: register-client
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /etc/acme-dns
+              name: acmedns-client-secret
+              readOnly: true
+            - mountPath: /home/acme-dns
+              name: home
+            - mountPath: /scripts
+              name: scripts
+          workingDir: /home/acme-dns
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: acme-dns
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: acmedns-client-secret
+          secret:
+            secretName: acme-dns-client
+        - emptyDir: {}
+          name: home
+        - configMap:
+            defaultMode: 448
+            name: register-acme-dns-client
+          name: scripts
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: check-acme-dns-client
+  name: check-acme-dns-client
+  namespace: syn-cert-manager
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 20
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: check-acme-dns-client
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/check.sh
+              env:
+                - name: ACME_DNS_API
+                  value: acme-dns-api.example.com
+                - name: ACME_DNS_DOMAINS
+                  value: '["example.com", "apps.example.com"]'
+                - name: CLIENT_SECRET_NAME
+                  value: acme-dns-client
+                - name: CONFIG_PATH
+                  value: /etc/acme-dns
+                - name: HOME
+                  value: /home/acme-dns
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: SCRIPTS_PATH
+                  value: /scripts
+              envFrom:
+                - secretRef:
+                    name: acme-dns-register
+              image: quay.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
+              imagePullPolicy: IfNotPresent
+              name: check-client
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /etc/acme-dns
+                  name: acmedns-client-secret
+                  readOnly: true
+                - mountPath: /home/acme-dns
+                  name: home
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /home/acme-dns
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: acme-dns
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - name: acmedns-client-secret
+              secret:
+                secretName: acme-dns-client
+            - emptyDir: {}
+              name: home
+            - configMap:
+                defaultMode: 448
+                name: register-acme-dns-client
+              name: scripts
+  schedule: 47 1 * * *
+  successfulJobsHistoryLimit: 10

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -56,20 +56,21 @@ data:
     \ reregister=\"yes\"\nfi\n\nif [ -n \"${reregister}\" ]; then\n  \"${SCRIPTS_PATH}/register.sh\"\
     \ force\nfi\n"
   register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nreadonly\
-    \ orig_secret=$(kubectl -n \"${NAMESPACE}\"\\\n  get secret \"${CLIENT_SECRET_NAME}\"\
-    \ -ojson)\n\nif ! [ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\"\
+    \ orig_secret=\"$(kubectl -n \"${NAMESPACE}\" \\\n  get secret \"${CLIENT_SECRET_NAME}\"\
+    \ -ojson)\"\n\nif ! [ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\"\
     \ ]; then\n\n  reg=$(curl -XPOST -u \"${REG_USERNAME}:${REG_PASSWORD}\" \\\n \
     \   \"${ACME_DNS_API}/register\")\n  # Create acme-dns-client secret for provided\
     \ domain names.\n  # Required format for acmedns.json in `stringData`:\n  # {\n\
     \  #   \"example.com\": { registration output },\n  #   \"example.org\": { registration\
-    \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson origsecret \"${orig_secret}\"\
+    \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson orig_secret \"${orig_secret}\"\
     \ \\\n    --argjson reg \"${reg}\" \\\n    --argjson domains \"${ACME_DNS_DOMAINS}\"\
     \ \\\n    --arg client_secret_name \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace\
-    \ \"${NAMESPACE}\" \\\n    '$orig_secret + {\n      \"stringData\": {\n      \
-    \  \"acmedns.json\": (reduce $domains[] as $d ({}; . + { ($d): $reg })) | tojson\n\
-    \      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.yaml\"\n  #\
-    \ Use kubectl apply as the empty secret is created by ArgoCD\n  kubectl apply\
-    \ -f \"${HOME}/secret.yaml\"\nfi\n"
+    \ \"${NAMESPACE}\" \\\n    '($orig_secret\n      |del(.metadata.annotations.\"\
+    kubectl.kubernetes.io/last-applied-configuration\")\n     ) + {\n      \"stringData\"\
+    : {\n        \"acmedns.json\": (reduce $domains[] as $d ({}; . + { ($d): $reg\
+    \ })) | tojson\n      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.json\"\
+    \n  # Use kubectl apply as the empty secret is created by ArgoCD\n  kubectl apply\
+    \ -f \"${HOME}/secret.json\"\nfi\n"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -55,23 +55,24 @@ data:
     /update; then\n  echo \"Failed to update record... trying reregistration\"\n \
     \ reregister=\"yes\"\nfi\n\nif [ -n \"${reregister}\" ]; then\n  \"${SCRIPTS_PATH}/register.sh\"\
     \ force\nfi\n"
-  register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nreadonly\
-    \ orig_secret=\"$(kubectl -n \"${NAMESPACE}\" \\\n  get secret \"${CLIENT_SECRET_NAME}\"\
-    \ -ojson)\"\n\nreg_auth_args=\nif [ -n \"${REG_USERNAME}\" ]; then\n  reg_auth_args=\"\
-    -u\\\"${REG_USERNAME}:${REG_PASSWORD}\\\"\"\nfi\n\nif ! [ -f /etc/scripts/acmedns.json\
-    \ ] \\\n  || [ -n \"${force_register}\" ]; then\n\n  reg=$(curl -XPOST \"${reg_auth_args}\"\
-    \ \"${ACME_DNS_API}/register\")\n  # Create acme-dns-client secret for provided\
-    \ domain names.\n  # Required format for acmedns.json in `stringData`:\n  # {\n\
-    \  #   \"example.com\": { registration output },\n  #   \"example.org\": { registration\
-    \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson orig_secret \"${orig_secret}\"\
-    \ \\\n    --argjson reg \"${reg}\" \\\n    --argjson fqdns \"${ACME_DNS_FQDNS}\"\
-    \ \\\n    --arg client_secret_name \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace\
-    \ \"${NAMESPACE}\" \\\n    '($orig_secret\n      |del(.metadata.annotations.\"\
-    kubectl.kubernetes.io/last-applied-configuration\")\n     ) + {\n      \"stringData\"\
-    : {\n        \"acmedns.json\": (reduce $fqdns[] as $d ({}; . + { ($d): $reg }))\
-    \ | tojson\n      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.json\"\
-    \n  # Use kubectl apply as the empty secret is created by ArgoCD\n  kubectl apply\
-    \ -f \"${HOME}/secret.json\"\nfi\n"
+  register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\nreadonly\
+    \ client_creds_file=\"${CONFIG_PATH}/acmedns.json\"\n\nreadonly orig_secret=\"\
+    $(kubectl -n \"${NAMESPACE}\" \\\n  get secret \"${CLIENT_SECRET_NAME}\" -ojson)\"\
+    \n\nreg_auth_args=\nif [ -n \"${REG_USERNAME}\" ]; then\n  reg_auth_args=\"-u${REG_USERNAME}:${REG_PASSWORD}\"\
+    \nfi\n\n\nif ! [ -f \"${client_creds_file}\" ] \\\n  || [ -n \"${force_register}\"\
+    \ ]; then\n\n  reg=$(curl -XPOST \"${reg_auth_args}\" \"${ACME_DNS_API}/register\"\
+    )\n  # Create acme-dns-client secret for provided domain names.\n  # Required\
+    \ format for acmedns.json in `stringData`:\n  # {\n  #   \"example.com\": { registration\
+    \ output },\n  #   \"example.org\": { registration output }\n  # }\n  client_secret=$(jq\
+    \ -n \\\n    --argjson orig_secret \"${orig_secret}\" \\\n    --argjson reg \"\
+    ${reg}\" \\\n    --argjson fqdns \"${ACME_DNS_FQDNS}\" \\\n    --arg client_secret_name\
+    \ \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace \"${NAMESPACE}\" \\\n    '($orig_secret\n\
+    \      |del(.metadata.annotations.\"kubectl.kubernetes.io/last-applied-configuration\"\
+    )\n     ) + {\n      \"stringData\": {\n        \"acmedns.json\": (reduce $fqdns[]\
+    \ as $d ({}; . + { ($d): $reg })) | tojson\n      }\n    }')\n\n  echo \"${client_secret}\"\
+    \ >\"${HOME}/secret.json\"\n  # Use kubectl apply as the empty secret is created\
+    \ by ArgoCD\n  kubectl apply -f \"${HOME}/secret.json\"\nelse\n  echo \"Client\
+    \ credentials config '${client_creds_file}' already exists.\"\nfi\n"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -55,21 +55,21 @@ data:
     /update; then\n  echo \"Failed to update record... trying reregistration\"\n \
     \ reregister=\"yes\"\nfi\n\nif [ -n \"${reregister}\" ]; then\n  \"${SCRIPTS_PATH}/register.sh\"\
     \ force\nfi\n"
-  register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nif ! [\
-    \ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\" ]; then\n\
-    \n  reg=$(curl -XPOST -u \"${REG_USERNAME}:${REG_PASSWORD}\" \\\n    \"${ACME_DNS_API}/register\"\
-    )\n  # Create acme-dns-client secret for provided domain names.\n  # Required\
-    \ format for acmedns.json in `stringData`:\n  # {\n  #   \"example.com\": { registration\
-    \ output },\n  #   \"example.org\": { registration output }\n  # }\n  client_secret=$(jq\
-    \ -n \\\n    --argjson reg \"${reg}\" \\\n    --argjson domains \"${ACME_DNS_DOMAINS}\"\
+  register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nreadonly\
+    \ orig_secret=$(kubectl -n \"${NAMESPACE}\"\\\n  get secret \"${CLIENT_SECRET_NAME}\"\
+    \ -ojson)\n\nif ! [ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\"\
+    \ ]; then\n\n  reg=$(curl -XPOST -u \"${REG_USERNAME}:${REG_PASSWORD}\" \\\n \
+    \   \"${ACME_DNS_API}/register\")\n  # Create acme-dns-client secret for provided\
+    \ domain names.\n  # Required format for acmedns.json in `stringData`:\n  # {\n\
+    \  #   \"example.com\": { registration output },\n  #   \"example.org\": { registration\
+    \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson origsecret \"${orig_secret}\"\
+    \ \\\n    --argjson reg \"${reg}\" \\\n    --argjson domains \"${ACME_DNS_DOMAINS}\"\
     \ \\\n    --arg client_secret_name \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace\
-    \ \"${NAMESPACE}\" \\\n    '{\n      \"apiVersion\": \"v1\",\n      \"kind\":\
-    \ \"Secret\",\n      \"type\": \"Opaque\",\n      \"metadata\": {\n        \"\
-    name\": $client_secret_name,\n        \"namespace\": $namespace,\n      },\n \
-    \     \"stringData\": {\n        \"acmedns.json\": (reduce $domains[] as $d ({};\
-    \ . + { ($d): $reg })) | tojson\n      }\n    }')\n\n  echo \"${client_secret}\"\
-    \ >\"${HOME}/secret.yaml\"\n  # Use kubectl apply as the empty secret is created\
-    \ by ArgoCD\n  kubectl apply -f \"${HOME}/secret.yaml\"\nfi\n"
+    \ \"${NAMESPACE}\" \\\n    '$orig_secret + {\n      \"stringData\": {\n      \
+    \  \"acmedns.json\": (reduce $domains[] as $d ({}; . + { ($d): $reg })) | tojson\n\
+    \      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.yaml\"\n  #\
+    \ Use kubectl apply as the empty secret is created by ArgoCD\n  kubectl apply\
+    \ -f \"${HOME}/secret.yaml\"\nfi\n"
 kind: ConfigMap
 metadata:
   annotations: {}

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -57,9 +57,10 @@ data:
     \ force\nfi\n"
   register.sh: "#!/bin/sh\n\nset -e\n\nreadonly force_register=\"${1}\"\n\nreadonly\
     \ orig_secret=\"$(kubectl -n \"${NAMESPACE}\" \\\n  get secret \"${CLIENT_SECRET_NAME}\"\
-    \ -ojson)\"\n\nif ! [ -f /etc/scripts/acmedns.json ] \\\n  || [ -n \"${force_register}\"\
-    \ ]; then\n\n  reg=$(curl -XPOST -u \"${REG_USERNAME}:${REG_PASSWORD}\" \\\n \
-    \   \"${ACME_DNS_API}/register\")\n  # Create acme-dns-client secret for provided\
+    \ -ojson)\"\n\nreg_auth_args=\nif [ -n \"${REG_USERNAME}\" ]; then\n  reg_auth_args=\"\
+    -u\\\"${REG_USERNAME}:${REG_PASSWORD}\\\"\"\nfi\n\nif ! [ -f /etc/scripts/acmedns.json\
+    \ ] \\\n  || [ -n \"${force_register}\" ]; then\n\n  reg=$(curl -XPOST \"${reg_auth_args}\"\
+    \ \"${ACME_DNS_API}/register\")\n  # Create acme-dns-client secret for provided\
     \ domain names.\n  # Required format for acmedns.json in `stringData`:\n  # {\n\
     \  #   \"example.com\": { registration output },\n  #   \"example.org\": { registration\
     \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson orig_secret \"${orig_secret}\"\

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -46,7 +46,7 @@ data:
   check.sh: "#!/bin/sh\n\nset -e\n\n# Extract acme-dns client config from mounted\
     \ secret file with `jq` and inject\n# as variables into the script environment\
     \ with `eval`.\nusername=\npassword=\nsubdomain=\nacmedns_config=$(jq -r --argjson\
-    \ domains \"${ACME_DNS_DOMAINS}\" '\n    .[$domains[0]]\n    | \"username=\\(.username)\
+    \ fqdns \"${ACME_DNS_FQDNS}\" '\n    .[$fqdns[0]]\n    | \"username=\\(.username)\
     \ password=\\(.password) subdomain=\\(.subdomain)\"\n  ' \"${CONFIG_PATH}/acmedns.json\"\
     )\n# This overrides the empty variables declared above\neval \"${acmedns_config}\"\
     \n\nreregister=\nif ! curl \\\n  -H\"X-Api-User: ${username}\" \\\n  -H\"X-Api-Key:\
@@ -64,12 +64,12 @@ data:
     \ domain names.\n  # Required format for acmedns.json in `stringData`:\n  # {\n\
     \  #   \"example.com\": { registration output },\n  #   \"example.org\": { registration\
     \ output }\n  # }\n  client_secret=$(jq -n \\\n    --argjson orig_secret \"${orig_secret}\"\
-    \ \\\n    --argjson reg \"${reg}\" \\\n    --argjson domains \"${ACME_DNS_DOMAINS}\"\
+    \ \\\n    --argjson reg \"${reg}\" \\\n    --argjson fqdns \"${ACME_DNS_FQDNS}\"\
     \ \\\n    --arg client_secret_name \"${CLIENT_SECRET_NAME}\" \\\n    --arg namespace\
     \ \"${NAMESPACE}\" \\\n    '($orig_secret\n      |del(.metadata.annotations.\"\
     kubectl.kubernetes.io/last-applied-configuration\")\n     ) + {\n      \"stringData\"\
-    : {\n        \"acmedns.json\": (reduce $domains[] as $d ({}; . + { ($d): $reg\
-    \ })) | tojson\n      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.json\"\
+    : {\n        \"acmedns.json\": (reduce $fqdns[] as $d ({}; . + { ($d): $reg }))\
+    \ | tojson\n      }\n    }')\n\n  echo \"${client_secret}\" >\"${HOME}/secret.json\"\
     \n  # Use kubectl apply as the empty secret is created by ArgoCD\n  kubectl apply\
     \ -f \"${HOME}/secret.json\"\nfi\n"
 kind: ConfigMap
@@ -130,7 +130,7 @@ spec:
           env:
             - name: ACME_DNS_API
               value: acme-dns-api.example.com
-            - name: ACME_DNS_DOMAINS
+            - name: ACME_DNS_FQDNS
               value: '["example.com", "apps.example.com"]'
             - name: CLIENT_SECRET_NAME
               value: acme-dns-client
@@ -205,7 +205,7 @@ spec:
               env:
                 - name: ACME_DNS_API
                   value: acme-dns-api.example.com
-                - name: ACME_DNS_DOMAINS
+                - name: ACME_DNS_FQDNS
                   value: '["example.com", "apps.example.com"]'
                 - name: CLIENT_SECRET_NAME
                   value: acme-dns-client


### PR DESCRIPTION
This PR extends the component with support for self-registration on an existing acme-dns instance. The registration itself is done by script `component/acme-dns-scripts/register.sh`. Regular checking of the client credentials (and reregistration if the credentials don't function) is done by script `component/acme-dns-scripts/check.sh`.

The shell scripts in `component/acme-dns-scripts` are deployed to the cluster in a configmap. The shell scripts expect their arguments as environment variables.

The component configures a Job which performs the initial registration and a CronJob which verifies the credentials every 24h.

The exact cronjob execution time is randomized between midnight and 2am, to avoid load spikes on the acme-dns API if many clusters are using the same acme-dns instance.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Rebase after #38 and #39 are merged

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
