### PR TITLE
Default apiGroup version to v1 in component library

### DIFF
--- a/lib/cert-manager.libsonnet
+++ b/lib/cert-manager.libsonnet
@@ -6,7 +6,16 @@
 
 local kube = import 'lib/kube.libjsonnet';
 
-local groupVersion = 'cert-manager.io/v1alpha2';
+local groupVersion =
+  if
+    std.objectHas(params, 'cert_manager') &&
+    std.startsWith(params.cert_manager.charts['cert-manager'], 'v0')
+  then
+    // legacy variant: use v1alpha2 for v0.x chart versions
+    'cert-manager.io/v1alpha2'
+  else
+    // default to v1
+    'cert-manager.io/v1';
 
 /**
   * \brief Helper to create Certificate objects.


### PR DESCRIPTION
The component currently deploys cert-manager v1.4.0 by default.  For cert-manager v1.x, the component library should create cert-manager custom resources with apiVersion `cert-manager.io/v1`.

The component library now determines the custom resource apiVersion to use based on the Helm chart version that is being deployed. For version v1.x, the library uses `cert-manager.io/v1`, for all v0.x versions, the component library uses `cert-manager.io/v1alpha2`, which ensures that we support all versions starting from v0.11.x.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
