### PR TITLE
Add support for disabling acme-dns client registration

### DIFF
--- a/component/acme-dns.libsonnet
+++ b/component/acme-dns.libsonnet
@@ -179,7 +179,10 @@ local clientcheckCronjob =
     },
   };
 
-if std.objectHas(acme_dns_api, 'endpoint') then
+if
+  std.objectHas(acme_dns_api, 'endpoint')
+  && acme_dns_api.endpoint != null
+then
   {
     manifests: std.filter(
       function(it) it != null,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -90,10 +90,12 @@ type:: dictionary
 keys:: `endpoint`, `username`, `password`, `fqdns`
 default:: `{}`
 
-The component sets up a Job and Cronjob to register and check acme-dns client credentials if key `endpoint` is present in this parameter.
+The component sets up a Job and Cronjob to register and check acme-dns client credentials if key `endpoint` is present and non-null in this parameter.
+If key `endpoint` is missing or `null` the component doesn't configure the acme-dns client registration.
+
 For a detailed explanation of how the self-registration works, see the xref:explanations/acme-dns-self-registration.adoc[acme-dns self-registration] documentation.
 
-If key `endpoint` is present, the component expects that the other keys listed above are also present. The keys have the following meaning:
+If key `endpoint` is present and non-null, the component expects that the other keys listed above are also present. The keys have the following meaning:
 
 `endpoint`:: The HTTP API endpoint of the acme-dns instance
 `username`:: The HTTP basic authorization username for the acme-dns instance `/register` endpoint


### PR DESCRIPTION
Sometimes users may want to disable acme-dns client registration for individual clusters.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
