### PR TITLE
Add default resource requests

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -42,3 +42,17 @@ parameters:
           enabled: true
       extraArgs:
         - --dns01-recursive-nameservers="${cert_manager:dns01-recursive-nameservers}"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 512Mi
+      webhook:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+      cainjector:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-deployment.yaml
@@ -41,7 +41,10 @@ spec:
         image: quay.io/jetstack/cert-manager-cainjector:v1.5.4
         imagePullPolicy: IfNotPresent
         name: cert-manager
-        resources: {}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-cainjector

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
@@ -52,7 +52,10 @@ spec:
         ports:
         - containerPort: 9402
           protocol: TCP
-        resources: {}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 512Mi
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-deployment.yaml
@@ -68,7 +68,10 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
-        resources: {}
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
       securityContext:
         runAsNonRoot: true
       serviceAccountName: cert-manager-webhook


### PR DESCRIPTION
Requests are based on numbers observed with `kubectl top pods` on some clusters. This PR intentionally doesn't set any limits to avoid supplying a default configuration which causes unnecessary cert-manager restarts due to memory consumption.

Fixes #53

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
- [x] Rebase after merging #56 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
