### PR TITLE
Move postprocessing filter definitions to component class

### DIFF
--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -30,3 +30,13 @@ parameters:
         output_type: yaml
         input_paths:
           - cert-manager/component/upgrade.jsonnet
+
+  commodore:
+    postprocess:
+      filters:
+        - path: cert-manager/01_helmchart/cert-manager/templates
+          type: builtin
+          filter: helm_namespace
+          filterargs:
+            namespace: ${cert_manager:namespace}
+            create_namespace: "true"

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,7 +1,0 @@
-filters:
-  - path: cert-manager/01_helmchart/cert-manager/templates
-    type: builtin
-    filter: helm_namespace
-    filterargs:
-      namespace: ${cert_manager:namespace}
-      create_namespace: "true"


### PR DESCRIPTION
Filter definitions in `postprocess/filters.yml` have been soft-deprecated since Commodore v0.4.0, and will be fully deprecated in v0.16.0, cf. https://syn.tools/commodore/reference/deprecation-notices.html#_external_pp_filters

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
