### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -18,7 +18,7 @@ parameters:
           - cert-manager/helmcharts/cert-manager/${cert_manager:charts:cert-manager}/
         helm_values: ${cert_manager:helm_values}
         helm_params:
-          release_name: cert-manager
+          name: cert-manager
           namespace: ${cert_manager:namespace}
       - output_path: cert-manager/02_issuers
         input_type: jsonnet


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

