### PR TITLE
Upgrade to cert-manager v1.5.5

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,7 +3,7 @@ parameters:
     namespace: syn-cert-manager
     dns01-recursive-nameservers: "1.1.1.1:53"
     charts:
-      cert-manager: v1.5.4
+      cert-manager: v1.5.5
     http_proxy: ""
     https_proxy: ""
     no_proxy: ""

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -127,7 +127,7 @@ value:: https://github.com/projectsyn/component-cert-manager/blob/master/class/d
 
 The Helm values which the component uses to render the cert-manager Helm chart.
 
-See https://github.com/jetstack/cert-manager/blob/v1.5.4/deploy/charts/cert-manager/values.yaml[the cert-manager Helm chart] for all possible configurations.
+See https://github.com/jetstack/cert-manager/blob/v1.5.5/deploy/charts/cert-manager/values.yaml[the cert-manager Helm chart] for all possible configurations.
 
 == Example
 

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-deployment.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector
   namespace: syn-cert-manager
 spec:
@@ -26,8 +26,8 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cainjector
-        app.kubernetes.io/version: v1.5.4
-        helm.sh/chart: cert-manager-v1.5.4
+        app.kubernetes.io/version: v1.5.5
+        helm.sh/chart: cert-manager-v1.5.5
     spec:
       containers:
       - args:
@@ -38,7 +38,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-cainjector:v1.5.4
+        image: quay.io/jetstack/cert-manager-cainjector:v1.5.5
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector
   namespace: syn-cert-manager
 rules:
@@ -84,8 +84,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector
   namespace: syn-cert-manager
 roleRef:
@@ -106,8 +106,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector:leaderelection
   namespace: syn-cert-manager
 rules:
@@ -155,8 +155,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector:leaderelection
   namespace: syn-cert-manager
 roleRef:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cainjector
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-cainjector
   namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/crds.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/crds.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: certificaterequests.cert-manager.io
   namespace: syn-cert-manager
 spec:
@@ -949,8 +949,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: certificates.cert-manager.io
   namespace: syn-cert-manager
 spec:
@@ -2797,8 +2797,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: challenges.acme.cert-manager.io
   namespace: syn-cert-manager
 spec:
@@ -10251,8 +10251,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: clusterissuers.cert-manager.io
   namespace: syn-cert-manager
 spec:
@@ -19961,8 +19961,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: issuers.cert-manager.io
   namespace: syn-cert-manager
 spec:
@@ -29667,8 +29667,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: orders.acme.cert-manager.io
   namespace: syn-cert-manager
 spec:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager
   namespace: syn-cert-manager
 spec:
@@ -26,8 +26,8 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: cert-manager
-        app.kubernetes.io/version: v1.5.4
-        helm.sh/chart: cert-manager-v1.5.4
+        app.kubernetes.io/version: v1.5.5
+        helm.sh/chart: cert-manager-v1.5.5
     spec:
       containers:
       - args:
@@ -46,7 +46,7 @@ spec:
           value: ''
         - name: NO_PROXY
           value: ''
-        image: quay.io/jetstack/cert-manager-controller:v1.5.4
+        image: quay.io/jetstack/cert-manager-controller:v1.5.5
         imagePullPolicy: IfNotPresent
         name: cert-manager
         ports:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-issuers
   namespace: syn-cert-manager
 rules:
@@ -55,8 +55,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-clusterissuers
   namespace: syn-cert-manager
 rules:
@@ -103,8 +103,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-certificates
   namespace: syn-cert-manager
 rules:
@@ -173,8 +173,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-orders
   namespace: syn-cert-manager
 rules:
@@ -241,8 +241,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-challenges
   namespace: syn-cert-manager
 rules:
@@ -348,8 +348,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-ingress-shim
   namespace: syn-cert-manager
 rules:
@@ -420,8 +420,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
@@ -457,8 +457,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
   name: cert-manager-edit
@@ -497,8 +497,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-approve:cert-manager-io
   namespace: syn-cert-manager
 rules:
@@ -521,8 +521,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-certificatesigningrequests
   namespace: syn-cert-manager
 rules:
@@ -566,8 +566,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-issuers
   namespace: syn-cert-manager
 roleRef:
@@ -588,8 +588,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-clusterissuers
   namespace: syn-cert-manager
 roleRef:
@@ -610,8 +610,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-certificates
   namespace: syn-cert-manager
 roleRef:
@@ -632,8 +632,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-orders
   namespace: syn-cert-manager
 roleRef:
@@ -654,8 +654,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-challenges
   namespace: syn-cert-manager
 roleRef:
@@ -676,8 +676,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-ingress-shim
   namespace: syn-cert-manager
 roleRef:
@@ -698,8 +698,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-approve:cert-manager-io
   namespace: syn-cert-manager
 roleRef:
@@ -720,8 +720,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-controller-certificatesigningrequests
   namespace: syn-cert-manager
 roleRef:
@@ -742,8 +742,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager:leaderelection
   namespace: syn-cert-manager
 rules:
@@ -789,8 +789,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager:leaderelection
   namespace: syn-cert-manager
 roleRef:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/service.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager
   namespace: syn-cert-manager
 spec:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/serviceaccount.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager
   namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/servicemonitor.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/servicemonitor.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: cert-manager
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
     prometheus: default
   name: cert-manager
   namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-job.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-job.yaml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-startupapicheck
   namespace: syn-cert-manager
 spec:
@@ -25,15 +25,15 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: startupapicheck
-        app.kubernetes.io/version: v1.5.4
-        helm.sh/chart: cert-manager-v1.5.4
+        app.kubernetes.io/version: v1.5.5
+        helm.sh/chart: cert-manager-v1.5.5
     spec:
       containers:
       - args:
         - check
         - api
         - --wait=1m
-        image: quay.io/jetstack/cert-manager-ctl:v1.5.4
+        image: quay.io/jetstack/cert-manager-ctl:v1.5.5
         imagePullPolicy: IfNotPresent
         name: cert-manager
         resources: {}

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-rbac.yaml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-startupapicheck:create-cert
   namespace: syn-cert-manager
 rules:
@@ -36,8 +36,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-startupapicheck:create-cert
   namespace: syn-cert-manager
 roleRef:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-serviceaccount.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/startupapicheck-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: startupapicheck
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-startupapicheck
   namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-deployment.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook
   namespace: syn-cert-manager
 spec:
@@ -26,8 +26,8 @@ spec:
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: webhook
-        app.kubernetes.io/version: v1.5.4
-        helm.sh/chart: cert-manager-v1.5.4
+        app.kubernetes.io/version: v1.5.5
+        helm.sh/chart: cert-manager-v1.5.5
     spec:
       containers:
       - args:
@@ -41,7 +41,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/jetstack/cert-manager-webhook:v1.5.4
+        image: quay.io/jetstack/cert-manager-webhook:v1.5.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook
   namespace: syn-cert-manager
 webhooks:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook:subjectaccessreviews
   namespace: syn-cert-manager
 rules:
@@ -28,8 +28,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook:subjectaccessreviews
   namespace: syn-cert-manager
 roleRef:
@@ -51,8 +51,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook:dynamic-serving
   namespace: syn-cert-manager
 rules:
@@ -83,8 +83,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook:dynamic-serving
   namespace: syn-cert-manager
 roleRef:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-service.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-service.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook
   namespace: syn-cert-manager
 spec:

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook
   namespace: syn-cert-manager

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/webhook-validating-webhook.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: webhook
-    app.kubernetes.io/version: v1.5.4
-    helm.sh/chart: cert-manager-v1.5.4
+    app.kubernetes.io/version: v1.5.5
+    helm.sh/chart: cert-manager-v1.5.5
   name: cert-manager-webhook
   namespace: syn-cert-manager
 webhooks:


### PR DESCRIPTION
The version v1.5.4 has incompatibilities with some ingress controllers.

Ref:
* https://cert-manager.io/docs/installation/upgrading/ingress-class-compatibility/

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

