### PR TITLE
Fix DNS01 challenge self-check

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -42,6 +42,7 @@ parameters:
           enabled: true
       extraArgs:
         - --dns01-recursive-nameservers="${cert_manager:dns01-recursive-nameservers}"
+        - --dns01-recursive-nameservers-only
       resources:
         requests:
           cpu: 50m

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -37,6 +37,12 @@ See the https://cert-manager.io/docs/configuration/acme/dns01/#setting-nameserve
 
 This parameter is injected into parameter `helm_values` as an extra argument to cert-manager (`helm_values.extraArgs`).
 
+[NOTE]
+====
+We additionally also set `--dns01-recursive-nameservers-only` as an argument to cert-manager.
+This ensures that only the nameservers configured in this parameter are used to validate DNS01 challenges.
+====
+
 == `http_proxy`
 
 [horizontal]

--- a/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/01_helmchart/cert-manager/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         - --cluster-resource-namespace=$(POD_NAMESPACE)
         - --leader-election-namespace=syn-cert-manager
         - --dns01-recursive-nameservers="1.1.1.1:53"
+        - --dns01-recursive-nameservers-only
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
We specify custom recursive nameservers for cert-manager to use when validating DNS01 challenges. However, in some cases, cert-manager will still try to connect to the DNS01 DNS server directly, unless the command line argument `--dns01-recursive-nameservers-only` is given as well.

Since the intention of the config is to be able to specify exactly which nameservers cert-manager should use, we need to also give
`--dns01-recursive-nameservers-only` to ensure that cert-manager always uses the configured recursive nameservers.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
