### PR TITLE
Change registry for `bitnami/kubectl` to docker.io

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,7 +21,7 @@ parameters:
     #   fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
     images:
       kubectl:
-        registry: quay.io
+        registry: docker.io
         image: bitnami/kubectl
         tag: '1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576'
 

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -150,7 +150,7 @@ spec:
           envFrom:
             - secretRef:
                 name: acme-dns-register
-          image: quay.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
+          image: docker.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
           imagePullPolicy: IfNotPresent
           name: register-client
           ports: []
@@ -225,7 +225,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: acme-dns-register
-              image: quay.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
+              image: docker.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
               imagePullPolicy: IfNotPresent
               name: check-client
               ports: []

--- a/tests/golden/defaults/cert-manager/cert-manager/03_upgrade/00_upgrade.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/03_upgrade/00_upgrade.yaml
@@ -86,7 +86,7 @@ spec:
                 orders.acme.cert-manager.io
             - name: HOME
               value: /export
-          image: quay.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
+          image: docker.io/bitnami/kubectl:1.21.2@sha256:a6c97fa2af65cf390447d96e7d0ca04f2d8c5035a50e62e1bc6b9eac28c3f576
           imagePullPolicy: IfNotPresent
           name: cert-manager-crd-upgrade
           ports: []


### PR DESCRIPTION
The bitnami images have disappeared on quay.io. According to https://blog.bitnami.com/2021/07/vmware-joins-docker-verified-publisher.html docker.io/bitnami should be exempt from the pull rate limits.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
