### PR TITLE
Make acme-dns registration job an ArgoCD sync hook

### DIFF
--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -101,7 +101,7 @@ kind: Secret
 metadata:
   annotations:
     cert-manager.syn.tools/managed-by: The contents of this secret are managed by
-      resources Job/register-acme-dns-client and CronJob/check-acme-dns-client
+      resources Job/create-acme-dns-client and CronJob/check-acme-dns-client
   labels:
     name: acme-dns-client
   name: acme-dns-client
@@ -111,10 +111,12 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
   labels:
-    name: register-acme-dns-client
-  name: register-acme-dns-client
+    name: create-acme-dns-client
+  name: create-acme-dns-client
   namespace: syn-cert-manager
 spec:
   completions: 1
@@ -122,7 +124,7 @@ spec:
   template:
     metadata:
       labels:
-        name: register-acme-dns-client
+        name: create-acme-dns-client
     spec:
       containers:
         - args: []


### PR DESCRIPTION
Updating or recreating plain Jobs is basically impossible without a hard delete (`kubectl replace` doesn't work as far as I can tell), so we run the registration job as an ArgoCD hook and ensure it gets deleted when it succeeds. The registration script should always be a no-op when acme-dns credentials already exist for in the secret.

To ensure the old registration job is deleted and we don't get conflicts when trying to run the new hook job, we change the registration job's name to `create-acme-dns-client`.

Required for #80 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
