### PR TITLE
Make acme-dns script permissions `ug+rwx`

### DIFF
--- a/component/acme-dns.libsonnet
+++ b/component/acme-dns.libsonnet
@@ -137,8 +137,9 @@ local scriptPodSpec(name, script) = {
     },
     scripts: {
       configMap: {
-        // 0700
-        defaultMode: 448,
+        // We need mode 0770 for the scripts, so they work correctly on OCP
+        // 4.11 where the configmap contents are owned by root:<pod-GID>.
+        defaultMode: std.parseOctal('770'),
         name: scriptConfigmap.metadata.name,
       },
     },

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -183,7 +183,7 @@ spec:
         - emptyDir: {}
           name: home
         - configMap:
-            defaultMode: 448
+            defaultMode: 504
             name: register-acme-dns-client
           name: scripts
 ---
@@ -264,7 +264,7 @@ spec:
             - emptyDir: {}
               name: home
             - configMap:
-                defaultMode: 448
+                defaultMode: 504
                 name: register-acme-dns-client
               name: scripts
   schedule: 47 1 * * *


### PR DESCRIPTION
This is required for OCP 4.11, as otherwise the job pod (which runs with an arbitrary UID/GID) can't execute the script, as the ConfigMap is mounted with owner root and group matching the pod's GID.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
