### PR TITLE
Use `quay.io/appuio/oc` image to run `kubectl` and `curl`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,9 +21,9 @@ parameters:
     #   fqdns: [ "api.cluster.example.com", "apps.cluster.example.com" ]
     images:
       kubectl:
-        registry: docker.io
-        image: bitnami/kubectl
-        tag: '1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598'
+        registry: quay.io
+        image: appuio/oc
+        tag: 'v4.12'
 
     helm_values:
       global:

--- a/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/02_issuers/20_acme_dns.yaml
@@ -205,7 +205,7 @@ spec:
           envFrom:
             - secretRef:
                 name: acme-dns-register
-          image: docker.io/bitnami/kubectl:1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598
+          image: quay.io/appuio/oc:v4.12
           imagePullPolicy: IfNotPresent
           name: register-client
           ports: []
@@ -286,7 +286,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: acme-dns-register
-              image: docker.io/bitnami/kubectl:1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598
+              image: quay.io/appuio/oc:v4.12
               imagePullPolicy: IfNotPresent
               name: check-client
               ports: []

--- a/tests/golden/defaults/cert-manager/cert-manager/03_upgrade/00_upgrade.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/03_upgrade/00_upgrade.yaml
@@ -92,7 +92,7 @@ spec:
                 orders.acme.cert-manager.io
             - name: HOME
               value: /export
-          image: docker.io/bitnami/kubectl:1.25.5@sha256:d4a21c081ec10396029758e340ec9ba09bc9dbc9066bb0f55f1cba56ab1cf598
+          image: quay.io/appuio/oc:v4.12
           imagePullPolicy: IfNotPresent
           name: cert-manager-crd-upgrade
           ports: []


### PR DESCRIPTION
The bitnami `kubectl` container image has removed `curl` (cf. https://github.com/bitnami/containers/issues/13820), so it's not suitable for the acme-dns registration and check scripts anymore.

We switch to the APPUiO-managed `oc` image which comes with `kubectl` and `curl`. This image should work fine on any K8s distribution.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
