### PR TITLE
Label namespace to ensure that cert-manager is monitored

### DIFF
--- a/component/namespace.jsonnet
+++ b/component/namespace.jsonnet
@@ -1,11 +1,22 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prometheus.libsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.cert_manager;
 
-local namespace = kube.Namespace(params.namespace);
+local namespace = kube.Namespace(params.namespace) {
+  metadata+: {
+    labels+: {
+      'openshift.io/cluster-monitoring': 'true',
+    },
+  },
+};
 
 {
-  '00_namespace': namespace,
+  '00_namespace':
+    if std.member(inv.applications, 'prometheus') then
+      prom.RegisterNamespace(namespace)
+    else
+      namespace,
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -10,6 +10,9 @@ default:: `syn-cert-manager`
 
 The namespace in which to install cert-manager.
 
+The component always adds label `openshift.io/cluster-monitoring=true` to the namespace.
+Additionally, if component `prometheus` is installed on the cluster, the component registers the namespace to be monitored through the default Prometheus stack managed by that component.
+
 == `charts:cert-manager`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,4 +1,13 @@
+applications:
+  - prometheus
+
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
   cert_manager:
     letsencrypt_email: test@syn.tools
     acme_dns_api:
@@ -8,3 +17,6 @@ parameters:
       fqdns:
         - example.com
         - apps.example.com
+
+  prometheus:
+    defaultInstance: infra-monitoring

--- a/tests/golden/defaults/cert-manager/cert-manager/00_namespace.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/00_namespace.yaml
@@ -3,5 +3,7 @@ kind: Namespace
 metadata:
   annotations: {}
   labels:
+    monitoring.syn.tools/infra-monitoring: 'true'
     name: syn-cert-manager
+    openshift.io/cluster-monitoring: 'true'
   name: syn-cert-manager


### PR DESCRIPTION
We add label `openshift.io/cluster-monitoring=true` to ensure the cert-manager installation is monitored by the OpenShift cluster-monitoring stack on OpenShift 4.

Additionally, if component `prometheus` is present in the cluster, we label the cert-manager namespace so that cert-manager is monitored through the default monitoring stack managed by component `prometheus`.

Resolves #23 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
