### PR TITLE
Add kube_version variable to ensure helm renders manifests correctly

### DIFF
--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -20,6 +20,7 @@ parameters:
         helm_params:
           name: cert-manager
           namespace: ${cert_manager:namespace}
+          kube_version: ${cert_manager:kubernetes_version}
       - output_path: cert-manager/
         input_type: jsonnet
         output_type: yaml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,10 @@
 parameters:
   cert_manager:
     namespace: syn-cert-manager
+
+    # Used when rendering the Helm chart
+    kubernetes_version: "1.27"
+
     dns01-recursive-nameservers: "1.1.1.1:53"
     charts:
       cert-manager: v1.13.5

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -13,6 +13,16 @@ The namespace in which to install cert-manager.
 The component always adds label `openshift.io/cluster-monitoring=true` to the namespace.
 Additionally, if component `prometheus` is installed on the cluster, the component registers the namespace to be monitored through the default Prometheus stack managed by that component.
 
+== `kubernetes_version`
+
+[horizontal]
+type:: string
+default:: https://github.com/projectsyn/component-cert-manager/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+The Kubernetes version to provide to `helm template` when rendering the Helm chart.
+
+TIP: Set this parameter to `${dynamic_facts:kubernetesVersion:major}.${dynamic_facts:kubernetesVersion.minor}` to use the cluster's reported Kubernetes version when rendering the Helm chart.
+
 == `charts:cert-manager`
 
 [horizontal]


### PR DESCRIPTION
We need to set the kube_version helm parameter in order to ensure that commodore will render the manifests for the correct kubernetes version




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
