### PR TITLE
Fix acmeClients precedence over legacy client

### DIFF
--- a/component/legacy.libsonnet
+++ b/component/legacy.libsonnet
@@ -8,14 +8,14 @@ local params = inv.parameters.cert_manager;
 // Define exports below
 {
   helmValues: params.helmValues.cert_manager + com.makeMergeable(
-    if std.objectHas(params, 'helm_values') && !std.objectHas(params.acmeClients, 'acme-dns') then std.trace('Parameter `helm_values` is deprecated, please use `helmValues.cert_manager`.', params.helm_values) else {},
+    if std.objectHas(params, 'helm_values') then std.trace('Parameter `helm_values` is deprecated, please use `helmValues.cert_manager`.', params.helm_values) else {},
   ),
   recursiveNameservers: if std.objectHas(params, 'dns01-recursive-nameservers') then std.trace('Parameter `recursiveNameservers` is deprecated, please use `components.cert_manager.recursiveNameservers`.', std.get(params, 'dns01-recursive-nameservers')) else params.components.cert_manager.recursiveNameservers,
   httpProxy: if std.objectHas(params, 'http_proxy') then std.trace('Parameter `http_proxy` is deprecated, please use `components.cert_manager.httpProxy`.', params.http_proxy) else params.components.cert_manager.httpProxy,
   httpsProxy: if std.objectHas(params, 'https_proxy') then std.trace('Parameter `https_proxy` is deprecated, please use `components.cert_manager.httpsProxy`.', params.https_proxy) else params.components.cert_manager.httpsProxy,
   noProxy: if std.objectHas(params, 'no_proxy') then std.trace('Parameter `no_proxy` is deprecated, please use `components.cert_manager.noProxy`.', params.no_proxy) else params.components.cert_manager.noProxy,
 
-  acmeClient: if std.objectHas(params, 'acme_dns_api') then std.trace('Parameter `acme_dns_api` is deprecated, please use `acmeClients`.', {
+  acmeClient: if std.objectHas(params, 'acme_dns_api') && !std.objectHas(params.acmeClients, 'acme-dns') then std.trace('Parameter `acme_dns_api` is deprecated, please use `acmeClients`.', {
     'acme-dns': {
       api: {
         endpoint: params.acme_dns_api.endpoint,


### PR DESCRIPTION
If an acmeClient named acme-dns is defined it has precedence over the legacy client, which has the same name.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
