### PR TITLE
Patch exoscale-webhook deployment to use container port 8443

### DIFF
--- a/postprocess/patch-exoscale.jsonnet
+++ b/postprocess/patch-exoscale.jsonnet
@@ -24,6 +24,18 @@ local deploy_obj = com.yaml_load(deploy_file);
       template+: {
         spec+: {
           priorityClassName: 'system-cluster-critical',
+          containers: [
+            super.containers[0] {
+              args+: [
+                '--secure-port=8443',
+              ],
+              ports: [
+                super.ports[0] {
+                  containerPort: 8443,
+                },
+              ],
+            },
+          ],
         },
       },
     },

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/exoscale-webhook/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/exoscale-webhook/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
+            - --secure-port=8443
           env:
             - name: GROUP_NAME
               value: acme.exoscale.com
@@ -40,7 +41,7 @@ spec:
               scheme: HTTPS
           name: exoscale-webhook
           ports:
-            - containerPort: 443
+            - containerPort: 8443
               name: https
               protocol: TCP
           readinessProbe:


### PR DESCRIPTION
We do this unconditionally, since there's no reason why a container should use a privileged port on K8s. We don't need to modify the service manifest since that uses the port name (`https`) to define the backend.

Fixes #173 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
