### PR TITLE
Generates acme spec for Let's Encrypt for all Issuers starting with letsencrypt

### DIFF
--- a/component/issuers.libsonnet
+++ b/component/issuers.libsonnet
@@ -18,9 +18,12 @@ local namespacedName(string) = {
 };
 
 // Let's Encrypt convenience
-local isLetsEncrypt(string) = std.member([ 'letsencrypt-staging', 'letsencrypt-production' ], string);
-local letsEncryptServer(string) = if string == 'letsencrypt-staging' then 'https://acme-staging-v02.api.letsencrypt.org/directory'
-else if string == 'letsencrypt-production' then 'https://acme-v02.api.letsencrypt.org/directory'
+local isLetsEncrypt(string) = std.any([
+  std.startsWith(string, prefix)
+  for prefix in [ 'letsencrypt-staging', 'letsencrypt-production' ]
+]);
+local letsEncryptServer(string) = if std.startsWith(string, 'letsencrypt-staging') then 'https://acme-staging-v02.api.letsencrypt.org/directory'
+else if std.startsWith(string, 'letsencrypt-production') then 'https://acme-v02.api.letsencrypt.org/directory'
 else '';
 
 // Merge letsencrypt acme config if named letsencrypt

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -214,6 +214,11 @@ cluster_issuers:
 
 Configuration for cluster-wide certificate issuers.
 
+[TIP]
+====
+If the issuer name starts with `letsencrypt-staging` or `letsencrypt-production`, the component will automatically be rendered to use the correct ACME server.
+====
+
 See the https://cert-manager.io/docs/concepts/issuer/[cert-manager documentation] for how to configure such issuers.
 
 === Example

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -30,6 +30,9 @@ parameters:
             secretName: ca-key-pair
 
     cluster_issuers:
+      letsencrypt-production-test:
+        solverRefs:
+          - nginx_http01
       letsencrypt-production:
         acmeClientRefs:
           - acme-dns

--- a/tests/golden/defaults/cert-manager/cert-manager/60_clusterissuer.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/60_clusterissuer.yaml
@@ -39,6 +39,23 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   labels:
+    name: letsencrypt-production-test
+  name: letsencrypt-production-test
+spec:
+  acme:
+    email: test@syn.tools
+    privateKeySecretRef:
+      name: letsencrypt-production-test
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  labels:
     name: letsencrypt-staging
   name: letsencrypt-staging
 spec:


### PR DESCRIPTION
Currently the acme spec gets only generated for exact matches of either:
* `letsencrypt-production` or
* `letsencrypt-staging`

This change will generate specs when the name starts with those.

Fixes #172




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
