### PR TITLE
Fix not correctly setting namespace of cert-manager rolebinding

### DIFF
--- a/component/helm/exoscale-webhook.jsonnet
+++ b/component/helm/exoscale-webhook.jsonnet
@@ -14,6 +14,10 @@ local component = {
     accessKey: params.components.exoscale_webhook.accessKey,
     secretKey: params.components.exoscale_webhook.secretKey,
   },
+  certManager: {
+    namespace: params.namespace,
+    serviceAccountName: 'cert-manager',
+  },
 };
 
 // Define outputs below

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/exoscale-webhook/templates/rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/exoscale-webhook/templates/rbac.yaml
@@ -62,7 +62,7 @@ subjects:
   - apiGroup: ''
     kind: ServiceAccount
     name: cert-manager
-    namespace: cert-manager
+    namespace: syn-cert-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Exoscale webhook was not aware of the namespace of cert-manager and created a wrong RoleBinding.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
