### PR TITLE
Add missing rendering of parameter `secrets`

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -38,8 +38,20 @@ local exoscaleSecret = kube.Secret('exoscale-secret') {
   data:: {},
 };
 
+local secrets = com.generateResources(
+  params.secrets,
+  function(s) std.prune(kube.Secret(s) {
+    metadata+: {
+      namespace: params.namespace,
+    },
+  })
+);
+
+
 {
   '00_namespace': if hasPrometheus then prom.RegisterNamespace(namespace) else namespace,
+  [if std.length(secrets) > 0 then '10_solver_secrets']:
+    secrets,
   [if params.components.exoscale_webhook.enabled then '90_secrets_exoscale']: exoscaleSecret,
 }
 + (import 'acme-dns.libsonnet')

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -41,5 +41,9 @@ parameters:
           ca:
             secretName: ca-key-pair
 
+    secrets:
+      issuer-key:
+        stringData: ?{vaultkv:${cluster:tenant}/${cluster:name}/custom-issuer/key}
+
   prometheus:
     defaultInstance: infra-monitoring

--- a/tests/golden/defaults/cert-manager/cert-manager/10_solver_secrets.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/10_solver_secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    name: issuer-key
+  name: issuer-key
+  namespace: syn-cert-manager
+stringData: t-silent-test-1234/c-green-test-1234/custom-issuer/key
+type: Opaque


### PR DESCRIPTION
This reintroduces rendering of Kubernetes secrets from the component parameter `secrets` which accidentally got removed in #162.

Based on e0791cae12cb6e9d7cfc0544fa0ae9de4d4b9b3f



## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
