### PR TITLE
Switch to server-side apply for acme-dns registration script

### DIFF
--- a/component/scripts/acme-register.sh
+++ b/component/scripts/acme-register.sh
@@ -5,9 +5,6 @@ set -e
 readonly force_register="${1}"
 readonly client_creds_file="${CONFIG_PATH}/acmedns.json"
 
-readonly orig_secret="$(kubectl -n "${NAMESPACE}" \
-  get secret "${CLIENT_SECRET_NAME}" -ojson)"
-
 reg_auth_args=
 if [ -n "${REG_USERNAME}" ]; then
   reg_auth_args="-u${REG_USERNAME}:${REG_PASSWORD}"
@@ -24,23 +21,28 @@ if ! [ -f "${client_creds_file}" ] \
   #   "example.com": { registration output },
   #   "example.org": { registration output }
   # }
+  # We create a partial secret here since we use server-side apply
   client_secret=$(jq -n \
-    --argjson orig_secret "${orig_secret}" \
     --argjson reg "${reg}" \
     --argjson fqdns "${ACME_DNS_FQDNS}" \
     --arg client_secret_name "${CLIENT_SECRET_NAME}" \
     --arg namespace "${NAMESPACE}" \
-    '($orig_secret
-      |del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")
-     ) + {
+    '{
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": $client_secret_name,
+        "namespace": $namespace,
+      },
       "stringData": {
         "acmedns.json": (reduce $fqdns[] as $d ({}; . + { ($d): $reg })) | tojson
       }
     }')
 
   echo "${client_secret}" >"${HOME}/secret.json"
-  # Use kubectl apply as the empty secret is created by ArgoCD
-  kubectl apply -f "${HOME}/secret.json"
+  # Use `kubectl apply --server-side=true` as the empty secret is created by
+  # ArgoCD with server-side apply.
+  kubectl apply --server-side=true -f "${HOME}/secret.json"
 else
   echo "Client credentials config '${client_creds_file}' already exists."
 fi

--- a/tests/golden/defaults/cert-manager/cert-manager/50_acme_dns_common.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/50_acme_dns_common.yaml
@@ -81,9 +81,6 @@ data:
     readonly force_register="${1}"
     readonly client_creds_file="${CONFIG_PATH}/acmedns.json"
 
-    readonly orig_secret="$(kubectl -n "${NAMESPACE}" \
-      get secret "${CLIENT_SECRET_NAME}" -ojson)"
-
     reg_auth_args=
     if [ -n "${REG_USERNAME}" ]; then
       reg_auth_args="-u${REG_USERNAME}:${REG_PASSWORD}"
@@ -100,23 +97,28 @@ data:
       #   "example.com": { registration output },
       #   "example.org": { registration output }
       # }
+      # We create a partial secret here since we use server-side apply
       client_secret=$(jq -n \
-        --argjson orig_secret "${orig_secret}" \
         --argjson reg "${reg}" \
         --argjson fqdns "${ACME_DNS_FQDNS}" \
         --arg client_secret_name "${CLIENT_SECRET_NAME}" \
         --arg namespace "${NAMESPACE}" \
-        '($orig_secret
-          |del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")
-         ) + {
+        '{
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": $client_secret_name,
+            "namespace": $namespace,
+          },
           "stringData": {
             "acmedns.json": (reduce $fqdns[] as $d ({}; . + { ($d): $reg })) | tojson
           }
         }')
 
       echo "${client_secret}" >"${HOME}/secret.json"
-      # Use kubectl apply as the empty secret is created by ArgoCD
-      kubectl apply -f "${HOME}/secret.json"
+      # Use `kubectl apply --server-side=true` as the empty secret is created by
+      # ArgoCD with server-side apply.
+      kubectl apply --server-side=true -f "${HOME}/secret.json"
     else
       echo "Client credentials config '${client_creds_file}' already exists."
     fi

--- a/tests/golden/legacy/cert-manager/cert-manager/50_acme_dns_common.yaml
+++ b/tests/golden/legacy/cert-manager/cert-manager/50_acme_dns_common.yaml
@@ -81,9 +81,6 @@ data:
     readonly force_register="${1}"
     readonly client_creds_file="${CONFIG_PATH}/acmedns.json"
 
-    readonly orig_secret="$(kubectl -n "${NAMESPACE}" \
-      get secret "${CLIENT_SECRET_NAME}" -ojson)"
-
     reg_auth_args=
     if [ -n "${REG_USERNAME}" ]; then
       reg_auth_args="-u${REG_USERNAME}:${REG_PASSWORD}"
@@ -100,23 +97,28 @@ data:
       #   "example.com": { registration output },
       #   "example.org": { registration output }
       # }
+      # We create a partial secret here since we use server-side apply
       client_secret=$(jq -n \
-        --argjson orig_secret "${orig_secret}" \
         --argjson reg "${reg}" \
         --argjson fqdns "${ACME_DNS_FQDNS}" \
         --arg client_secret_name "${CLIENT_SECRET_NAME}" \
         --arg namespace "${NAMESPACE}" \
-        '($orig_secret
-          |del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration")
-         ) + {
+        '{
+          "apiVersion": "v1",
+          "kind": "Secret",
+          "metadata": {
+            "name": $client_secret_name,
+            "namespace": $namespace,
+          },
           "stringData": {
             "acmedns.json": (reduce $fqdns[] as $d ({}; . + { ($d): $reg })) | tojson
           }
         }')
 
       echo "${client_secret}" >"${HOME}/secret.json"
-      # Use kubectl apply as the empty secret is created by ArgoCD
-      kubectl apply -f "${HOME}/secret.json"
+      # Use `kubectl apply --server-side=true` as the empty secret is created by
+      # ArgoCD with server-side apply.
+      kubectl apply --server-side=true -f "${HOME}/secret.json"
     else
       echo "Client credentials config '${client_creds_file}' already exists."
     fi


### PR DESCRIPTION
This is necessary now that we use server-side apply for the ArgoCD app.

If the registration script uses cliend-side apply, there's a race condition during the first sync where it's possible that ArgoCD's server-side apply overwrites the `acmedns.json` written by the registration sync job.

With server-side apply in the registration script, we can also switch back to just rendering a partial `Secret` resource instead of injecting the `acmedns.json` data into the secret we read from the cluster.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
