### PR TITLE
Update Helm release cert-manager-webhook-exoscale to v0.3.4

### DIFF
--- a/class/cert-manager.yml
+++ b/class/cert-manager.yml
@@ -6,7 +6,7 @@ parameters:
         input_paths:
           - ${_base_directory}/component/helm/exoscale-webhook.jsonnet
         input_type: jsonnet
-        output_path: ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:exoscale_webhook:version}/
+        output_path: ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:cert-manager-webhook-exoscale:version}/
       'False': &option_false
         input_paths: []
         input_type: jsonnet
@@ -14,11 +14,11 @@ parameters:
     exoscale_webhook_helm:
       'True':
         input_paths:
-          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:exoscale_webhook:version}/
+          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:cert-manager-webhook-exoscale:version}/
         input_type: helm
         helm_values_files:
-          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:exoscale_webhook:version}/values-component.yaml
-          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:exoscale_webhook:version}/values-overrides.yaml
+          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:cert-manager-webhook-exoscale:version}/values-component.yaml
+          - ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:cert-manager-webhook-exoscale:version}/values-overrides.yaml
         helm_params:
           name: exoscale-webhook
           namespace: ${cert_manager:namespace}
@@ -33,10 +33,10 @@ parameters:
         version: ${cert_manager:charts:cert-manager:version}
         output_path: ${_base_directory}/helmcharts/cert-manager/${cert_manager:charts:cert-manager:version}/
       - type: git
-        source: ${cert_manager:charts:exoscale_webhook:source}
-        ref: ${cert_manager:charts:exoscale_webhook:version}
+        source: ${cert_manager:charts:cert-manager-webhook-exoscale:source}
+        ref: ${cert_manager:charts:cert-manager-webhook-exoscale:version}
         subdir: deploy/exoscale-webhook
-        output_path: ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:exoscale_webhook:version}/
+        output_path: ${_base_directory}/helmcharts/exoscale-webhook/${cert_manager:charts:cert-manager-webhook-exoscale:version}/
 
     compile:
       - input_paths:
@@ -71,7 +71,7 @@ parameters:
           path: cert-manager/10_cert_manager/cert-manager/templates/
           filter: postprocess/patch-crds.jsonnet
         - type: jsonnet
-          path: cert-manager/20_exoscale_webhook/exoscale-webhook/templates/
+          path: cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/
           filter: postprocess/patch-exoscale.jsonnet
           enabled: ${cert_manager:components:exoscale_webhook:enabled}
         - type: jsonnet

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,9 +9,9 @@ parameters:
       cert-manager:
         source: https://charts.jetstack.io
         version: v1.20.0
-      exoscale_webhook:
+      cert-manager-webhook-exoscale:
         source: https://github.com/exoscale/cert-manager-webhook-exoscale.git
-        version: v0.3.0
+        version: v0.3.4
 
     images:
       cert_manager:
@@ -37,7 +37,7 @@ parameters:
       exoscale_webhook:
         registry: docker.io
         repository: exoscale/cert-manager-webhook-exoscale
-        tag: ${cert_manager:charts:exoscale_webhook:version}
+        tag: ${cert_manager:charts:cert-manager-webhook-exoscale:version}
       kubectl:
         registry: quay.io
         repository: appuio/oc

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -23,6 +23,11 @@ default:: https://github.com/projectsyn/component-cert-manager/blob/master/class
 
 Specifies the Helm charts sources and versions for certificate-related components.
 
+[NOTE]
+====
+Please note that the minimum chart version supported for cert-manager-exoscale-webhook is v0.3.4.
+====
+
 
 == `images`
 

--- a/postprocess/patch-crds.jsonnet
+++ b/postprocess/patch-crds.jsonnet
@@ -19,12 +19,12 @@ local crds = [
 
 {
   [crd.name]: crd.content[0] {
-      metadata+: {
-        annotations+: {
-          'argocd.argoproj.io/sync-options': 'Prune=false',
-          'argocd.argoproj.io/sync-wave': '-10',
-        },
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'Prune=false',
+        'argocd.argoproj.io/sync-wave': '-10',
       },
-    }
+    },
+  }
   for crd in crds
 }

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/apiservice.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/apiservice.yaml
@@ -5,7 +5,7 @@ metadata:
     cert-manager.io/inject-ca-from: syn-cert-manager/cert-manager-webhook-exoscale-webhook-tls
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: v1alpha1.acme.exoscale.com

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale
@@ -32,14 +32,14 @@ spec:
               value: ''
             - name: EXOSCALE_API_TRACE
               value: ''
-          image: docker.io/exoscale/cert-manager-webhook-exoscale:0.3.0
+          image: docker.io/exoscale/cert-manager-webhook-exoscale:0.3.4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
               path: /healthz
               port: https
               scheme: HTTPS
-          name: exoscale-webhook
+          name: cert-manager-webhook-exoscale-chart
           ports:
             - containerPort: 8443
               name: https

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/pki.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/pki.yaml
@@ -3,7 +3,7 @@ kind: Certificate
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale-ca
@@ -21,7 +21,7 @@ kind: Certificate
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale-webhook-tls
@@ -41,7 +41,7 @@ kind: Issuer
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale-selfsign
@@ -54,7 +54,7 @@ kind: Issuer
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale-ca

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/rbac.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/rbac.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale
@@ -14,7 +14,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:domain-solver
@@ -31,7 +31,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:auth-delegator
@@ -50,7 +50,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:domain-solver
@@ -69,7 +69,7 @@ kind: Role
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:secrets-reader
@@ -87,7 +87,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:webhook-authentication-reader
@@ -107,7 +107,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale:secrets-reader

--- a/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/service.yaml
+++ b/tests/golden/defaults/cert-manager/cert-manager/20_exoscale_webhook/cert-manager-webhook-exoscale-chart/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app: exoscale-webhook
-    chart: exoscale-webhook-0.3.0
+    chart: cert-manager-webhook-exoscale-chart-0.3.4
     heritage: Helm
     release: exoscale-webhook
   name: cert-manager-webhook-exoscale


### PR DESCRIPTION
This change is breaking because the path to the Exoscale webhook has changed
and therefor manually configuring an older chart version will break compilation.

Also we updated the parameter for the Exoscale webhook in order for renovate to find the chart.

If you do not configure the Exoscale webhook chart, you do not need to adjust your parameters.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
